### PR TITLE
Add multiple default values for each key and remove defaults casting exceptions

### DIFF
--- a/packages/conferer/src/Conferer/Config/Internal/Types.hs
+++ b/packages/conferer/src/Conferer/Config/Internal/Types.hs
@@ -21,7 +21,7 @@ import Data.Text (Text)
 data Config =
   Config
   { configSources :: [Source]
-  , configDefaults :: Map Key Dynamic
+  , configDefaults :: Map Key [Dynamic]
   , configKeyMappings :: [(Key, Key)]
   } deriving (Show)
 
@@ -29,7 +29,7 @@ data Config =
 data KeyLookupResult
   = MissingKey [Key]
   | FoundInSources Key Text
-  | FoundInDefaults Key Dynamic
+  | FoundInDefaults Key [Dynamic]
   deriving (Show)
 
 -- | The type for creating a source given a 'Config', some sources require a

--- a/packages/conferer/src/Conferer/FromConfig.hs
+++ b/packages/conferer/src/Conferer/FromConfig.hs
@@ -26,9 +26,6 @@ module Conferer.FromConfig
   , throwConfigParsingError
   , configParsingError
 
-  , TypeMismatchWithDefault
-  , throwTypeMismatchWithDefault
-  , typeMismatchWithDefault
   , Key
   , (/.)
   , File(..)

--- a/packages/conferer/test/Conferer/FromConfig/BoolSpec.hs
+++ b/packages/conferer/test/Conferer/FromConfig/BoolSpec.hs
@@ -12,7 +12,6 @@ spec = do
   context "Basic fetching" $ do
     describe "fetching a Bool from config" $ do
       ensureEmptyConfigThrows @Bool
-      ensureWrongTypeDefaultThrows @Bool
 
       ensureUsingDefaultReturnsSameValue @Bool True
       ensureUsingDefaultReturnsSameValue @Bool False

--- a/packages/conferer/test/Conferer/FromConfig/Extended.hs
+++ b/packages/conferer/test/Conferer/FromConfig/Extended.hs
@@ -13,7 +13,6 @@ module Conferer.FromConfig.Extended
   , aMissingRequiredKeys
   , aTypeMismatchWithDefaultError
   , ensureEmptyConfigThrows
-  , ensureWrongTypeDefaultThrows
   , ensureUsingDefaultReturnsSameValue
   , ensureSingleConfigParsesTheRightThing
   , ensureSingleConfigThrowsParserError
@@ -63,7 +62,7 @@ aMissingRequiredKeys keys (MissingRequiredKey k t) =
 aTypeMismatchWithDefaultError :: forall a dyn. (Typeable dyn, Typeable a) =>
   Key -> dyn -> TypeMismatchWithDefault -> Bool
 aTypeMismatchWithDefaultError key dyn e =
-  e == typeMismatchWithDefault @a key (toDyn dyn)
+  e == typeMismatchWithDefault @a key [toDyn dyn]
 
 data InvalidThing = InvalidThing deriving (Show, Eq)
 
@@ -74,15 +73,6 @@ ensureEmptyConfigThrows =
       config <- configWith []
       fetchFromConfig @a "some.key" config
         `shouldThrow` aMissingRequiredKey @a "some.key"
-
-ensureWrongTypeDefaultThrows :: forall a. (Typeable a, FromConfig a) => SpecWith ()
-ensureWrongTypeDefaultThrows =
-  context "with invalid types in the defaults"  $ do
-    it "throws an exception" $ do
-      config <- configWith []
-      fetchFromConfig @a "some.key"
-          (config & addDefault "some.key" InvalidThing)
-        `shouldThrow` aTypeMismatchWithDefaultError @a "some.key" InvalidThing
 
 ensureSingleConfigThrowsParserError ::
     forall a. (FromConfig a) =>

--- a/packages/conferer/test/Conferer/FromConfig/Extended.hs
+++ b/packages/conferer/test/Conferer/FromConfig/Extended.hs
@@ -11,7 +11,6 @@ module Conferer.FromConfig.Extended
   , aConfigParserError
   , aMissingRequiredKey
   , aMissingRequiredKeys
-  , aTypeMismatchWithDefaultError
   , ensureEmptyConfigThrows
   , ensureUsingDefaultReturnsSameValue
   , ensureSingleConfigParsesTheRightThing
@@ -58,11 +57,6 @@ aMissingRequiredKey key (MissingRequiredKey k t) =
 aMissingRequiredKeys :: forall t. Typeable t => [Key] -> MissingRequiredKey -> Bool
 aMissingRequiredKeys keys (MissingRequiredKey k t) =
   keys == k && typeRep (Proxy :: Proxy t) == t
-
-aTypeMismatchWithDefaultError :: forall a dyn. (Typeable dyn, Typeable a) =>
-  Key -> dyn -> TypeMismatchWithDefault -> Bool
-aTypeMismatchWithDefaultError key dyn e =
-  e == typeMismatchWithDefault @a key [toDyn dyn]
 
 data InvalidThing = InvalidThing deriving (Show, Eq)
 

--- a/packages/conferer/test/Conferer/FromConfig/FileSpec.hs
+++ b/packages/conferer/test/Conferer/FromConfig/FileSpec.hs
@@ -22,8 +22,6 @@ spec = do
           , "some.key.filename"
           ]
 
-      ensureFetchThrows @File [] [("", toDyn False)] $
-        aTypeMismatchWithDefaultError @File "some.key" False
       context "with whole path in root" $ do
         ensureFetchParses @File
           [ ("", pack $ "some" </> "file.png")

--- a/packages/conferer/test/Conferer/FromConfig/ListSpec.hs
+++ b/packages/conferer/test/Conferer/FromConfig/ListSpec.hs
@@ -20,7 +20,6 @@ spec :: Spec
 spec = do
   describe "list parsing" $ do
     ensureEmptyConfigThrows @[Int]
-    ensureWrongTypeDefaultThrows @[Int]
     ensureUsingDefaultReturnsSameValue @[Int] [7]
 
     context "with an empty keys it always gets an empty list" $ do

--- a/packages/conferer/test/Conferer/FromConfig/NumbersSpec.hs
+++ b/packages/conferer/test/Conferer/FromConfig/NumbersSpec.hs
@@ -14,7 +14,6 @@ spec = do
   context "Numbers fetching" $ do
     describe "fetching an Int from config" $ do
       ensureEmptyConfigThrows @Int
-      ensureWrongTypeDefaultThrows @Int
       ensureUsingDefaultReturnsSameValue @Int 7
       ensureSingleConfigParsesTheRightThing @Int "7" 7
       ensureSingleConfigParsesTheRightThing @Int "-7" (-7)
@@ -22,7 +21,6 @@ spec = do
 
     describe "fetching a Float from config" $ do
       ensureEmptyConfigThrows @Float
-      ensureWrongTypeDefaultThrows @Float
       ensureUsingDefaultReturnsSameValue @Float 7.5
       ensureSingleConfigParsesTheRightThing @Float "9.5" 9.5
       ensureSingleConfigParsesTheRightThing @Float "-9.5" (-9.5)

--- a/packages/conferer/test/Conferer/FromConfig/StringLikeSpec.hs
+++ b/packages/conferer/test/Conferer/FromConfig/StringLikeSpec.hs
@@ -12,21 +12,17 @@ spec :: Spec
 spec = do
     describe "fetching a String from config" $ do
       ensureEmptyConfigThrows @String
-      ensureWrongTypeDefaultThrows @String
       ensureUsingDefaultReturnsSameValue @String "aaa"
       ensureSingleConfigParsesTheRightThing @String "thing" "thing"
     describe "fetching text from config" $ do
       ensureEmptyConfigThrows @Text
-      ensureWrongTypeDefaultThrows @Text
       ensureUsingDefaultReturnsSameValue @Text "aaa"
       ensureSingleConfigParsesTheRightThing @Text "thing" "thing"
     describe "fetching bytestring from config" $ do
       ensureEmptyConfigThrows @BS.ByteString
-      ensureWrongTypeDefaultThrows @BS.ByteString
       ensureUsingDefaultReturnsSameValue @BS.ByteString "aaa"
       ensureSingleConfigParsesTheRightThing @BS.ByteString "thing" "thing"
     describe "fetching lazy bytestring from config" $ do
       ensureEmptyConfigThrows @LBS.ByteString
-      ensureWrongTypeDefaultThrows @LBS.ByteString
       ensureUsingDefaultReturnsSameValue @LBS.ByteString "aaa"
       ensureSingleConfigParsesTheRightThing @LBS.ByteString "thing" "thing"


### PR DESCRIPTION
### Problem:

Right now we have the defaults map inside the Config, which is used for defining defaults, if the programmer messes up and sets the wrong type for a default, there is nothing the user can do to get the program to work.

On a less pragmatic note, I'd like to have more than one default for each key (with possibly different types), to allow easier extension of the library using types instead of special keys (now that I'm thinking about it this would remediate some of the magic keys of the List FromConfig instance). Also it allows us to avoid removing keys from the defaults when we have some nested FromConfig instances.

### Proposed solution:

Firstly we should never throw when we find the wrong type in the defaults.

Secondly we should have a list of defaults in the defaults map instead of only one.