### PR TITLE
Fixed problems with hashable >= 1.3.1.0

### DIFF
--- a/docs/sources/json.md
+++ b/docs/sources/json.md
@@ -91,3 +91,6 @@ exposes
 * `"object"` not present
 * `"object.a"` mapped to `"1"`
 * `"object.keys"` mapped to `"a,b"`
+
+NOTE: The keys list is always sorted in lexicographical order, since aeson doesn't
+maintain the original order of keys, we sort it to be consistent.

--- a/packages/aeson/CHANGELOG.md
+++ b/packages/aeson/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [PVP](https://pvp.haskell.org/).
 
 ## [Unreleased]
 
-Nothing
+## Changed
+
+* Make the `keys` special key always return sorted keys (because of the change from hashable-1.3.1.0)
 
 ## [v1.1.0.0] 2021-03-01
 

--- a/packages/aeson/src/Conferer/Source/Aeson.hs
+++ b/packages/aeson/src/Conferer/Source/Aeson.hs
@@ -20,7 +20,7 @@ import qualified Data.Vector as Vector
 import Text.Read (readMaybe)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
-import Data.List (intersperse)
+import Data.List (intersperse, sort)
 import System.Directory (doesFileExist)
 import Control.Exception
 import Control.Monad (guard)
@@ -115,6 +115,7 @@ traverseJSON key value =
               String $
               mconcat $
               intersperse "," $
+              sort $
               HashMap.keys o)
    (Just (c, ks), Object o) ->
      HashMap.lookup c o >>= traverseJSON ks


### PR DESCRIPTION
# Description

hashable changes the ordering guaranties from aeson, so we need to sort
the keys from the `keys` special keys, to avoid depending on the ordering
that aeson provides.

# Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added changes to the relevant changelog
- [x] I have made corresponding changes to the documentation
- [x] I have added haddock comments for every new function and data
