### PR TITLE
Refactor getKey to improve interfaces to Config

### DIFF
--- a/packages/conferer/CHANGELOG.md
+++ b/packages/conferer/CHANGELOG.md
@@ -6,7 +6,19 @@ and this project adheres to [PVP](https://pvp.haskell.org/).
 
 ## [Unreleased]
 
-Nothing
+### Added
+
+* Added new functions `getKeyFromSources` and `getKeyFromDefaults`
+* Change structure of `KeyLookupResult` to keep invariants of `getKeyFromSources` `getKeyFromDefaults`
+
+### Removed
+
+* Removed `fetchFromDefaults` and `fetchRequiredFromDefaults` in favor of `getKeyFromDefaults`
+
+### Changed
+
+* `listSubkeys` now ignores the defaults (since without a type parameter we can't guarantee that a value
+    will always be found)
 
 ## [v1.1.0.0] - 2021-03-01
 

--- a/packages/conferer/src/Conferer/Config.hs
+++ b/packages/conferer/src/Conferer/Config.hs
@@ -12,7 +12,10 @@ module Conferer.Config
     Config
     -- * Querying a config
   , getKey
+  , getKeyFromDefaults
+  , getKeyFromSources
   , KeyLookupResult(..)
+  , LookupTarget(..)
   , listSubkeys
     -- * Config creation and initialization
   , emptyConfig

--- a/packages/conferer/src/Conferer/Config/Internal/Types.hs
+++ b/packages/conferer/src/Conferer/Config/Internal/Types.hs
@@ -45,9 +45,9 @@ data Config =
 --   * 'OnlySources': 'FoundInDefaults' constructor is not possible, type of
 --       of the result is always 'Text'
 data KeyLookupResult lookupTarget
-  = MissingKey (MissingC lookupTarget) [Key]
-  | FoundInSources (SourcesC lookupTarget) Key
-  | FoundInDefaults (DefaultsC lookupTarget) Key
+  = MissingKey () [Key]
+  | FoundInSources (SourcesResultType lookupTarget) Key
+  | FoundInDefaults (DefaultsResultType lookupTarget) Key
 
 -- | Target of a lookup that the 'KeyLookupResult' is parameterized on
 -- to indicate where the value was looked for in.
@@ -61,35 +61,27 @@ data LookupTarget a
  -- ^ Look only in the sources ('FoundInSources' is not possible)
  -- its type parameter indicates the type of the default
 
--- | Modifier type family for the 'MissingKey' constructor.
-type family MissingC (a :: LookupTarget Type) where
-  MissingC ('BothSourcesAndDefaults a) = ()
-  MissingC 'OnlySources = ()
-  MissingC ('OnlyDefaultsAs _) = ()
-
 -- | Modifier type family for the 'FoundInSources' constructor.
-type family SourcesC (a :: LookupTarget Type) where
-  SourcesC ('BothSourcesAndDefaults a) = Text
-  SourcesC 'OnlySources = Text
-  SourcesC ('OnlyDefaultsAs _) = Void
+type family SourcesResultType (a :: LookupTarget Type) where
+  SourcesResultType ('BothSourcesAndDefaults a) = Text
+  SourcesResultType 'OnlySources = Text
+  SourcesResultType ('OnlyDefaultsAs _) = Void
 
 -- | Modifier type family for the 'FoundInDefaults' constructor.
-type family DefaultsC (a :: LookupTarget Type) where
-  DefaultsC ('BothSourcesAndDefaults a) = a
-  DefaultsC 'OnlySources = Void
-  DefaultsC ('OnlyDefaultsAs a) = a
+type family DefaultsResultType (a :: LookupTarget Type) where
+  DefaultsResultType ('BothSourcesAndDefaults a) = a
+  DefaultsResultType 'OnlySources = Void
+  DefaultsResultType ('OnlyDefaultsAs a) = a
 
 deriving instance
-    ( Eq a, a ~ MissingC lookupTarget
-    , Eq b, b ~ DefaultsC lookupTarget
-    , Eq c, c ~ SourcesC lookupTarget
+    ( Eq b, b ~ DefaultsResultType lookupTarget
+    , Eq c, c ~ SourcesResultType lookupTarget
     )
   => Eq (KeyLookupResult lookupTarget)
 
 deriving instance
-    ( Show a, a ~ MissingC lookupTarget
-    , Show b, b ~ DefaultsC lookupTarget
-    , Show c, c ~ SourcesC lookupTarget
+    ( Show b, b ~ DefaultsResultType lookupTarget
+    , Show c, c ~ SourcesResultType lookupTarget
     )
   => Show (KeyLookupResult lookupTarget)
 

--- a/packages/conferer/src/Conferer/Config/Internal/Types.hs
+++ b/packages/conferer/src/Conferer/Config/Internal/Types.hs
@@ -6,6 +6,10 @@
 -- Portability: portable
 --
 -- Core types for Config (here because of depedency cycles)
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
 module Conferer.Config.Internal.Types where
 
 import Data.Map (Map)
@@ -13,6 +17,8 @@ import Conferer.Key (Key)
 import Data.Dynamic ( Dynamic )
 import Conferer.Source.Internal (Source)
 import Data.Text (Text)
+import Data.Void
+import Data.Kind
 
 -- | This type acts as the entry point for most of the library, it's main purpouse
 --   is to expose a uniform interface into multiple configuration sources (such as
@@ -26,11 +32,66 @@ data Config =
   } deriving (Show)
 
 -- | Result of a key lookup in a 'Config'
-data KeyLookupResult
-  = MissingKey [Key]
-  | FoundInSources Key Text
-  | FoundInDefaults Key [Dynamic]
-  deriving (Show)
+--
+-- This is indexed by 'LookupTarget' to indicate where we are looking for values
+-- and some invariants (if you look for defaults you'll never get things from a
+-- 'Source)
+--
+-- Possible valures are:
+--   * 'BothSourcesAndDefaults' a: All constructors are possible, type parameter
+--       indicates the type of the default to look for.
+--   * 'OnlyDefaultsAs' a: 'FoundInSources' constructor is not possible, type
+--       parameter indicates the type of the default to look for
+--   * 'OnlySources': 'FoundInDefaults' constructor is not possible, type of
+--       of the result is always 'Text'
+data KeyLookupResult lookupTarget
+  = MissingKey (MissingC lookupTarget) [Key]
+  | FoundInSources (SourcesC lookupTarget) Key
+  | FoundInDefaults (DefaultsC lookupTarget) Key
+
+-- | Target of a lookup that the 'KeyLookupResult' is parameterized on
+-- to indicate where the value was looked for in.
+data LookupTarget a
+ = BothSourcesAndDefaults a
+ -- ^ Look in both Sources and defaults (this is the most common)
+ -- its type parameter indicates the type of the default
+ | OnlySources
+ -- ^ Look only in the defaults ('FoundInDefaults' is not possible)
+ | OnlyDefaultsAs a
+ -- ^ Look only in the sources ('FoundInSources' is not possible)
+ -- its type parameter indicates the type of the default
+
+-- | Modifier type family for the 'MissingKey' constructor.
+type family MissingC (a :: LookupTarget Type) where
+  MissingC ('BothSourcesAndDefaults a) = ()
+  MissingC 'OnlySources = ()
+  MissingC ('OnlyDefaultsAs _) = ()
+
+-- | Modifier type family for the 'FoundInSources' constructor.
+type family SourcesC (a :: LookupTarget Type) where
+  SourcesC ('BothSourcesAndDefaults a) = Text
+  SourcesC 'OnlySources = Text
+  SourcesC ('OnlyDefaultsAs _) = Void
+
+-- | Modifier type family for the 'FoundInDefaults' constructor.
+type family DefaultsC (a :: LookupTarget Type) where
+  DefaultsC ('BothSourcesAndDefaults a) = a
+  DefaultsC 'OnlySources = Void
+  DefaultsC ('OnlyDefaultsAs a) = a
+
+deriving instance
+    ( Eq a, a ~ MissingC lookupTarget
+    , Eq b, b ~ DefaultsC lookupTarget
+    , Eq c, c ~ SourcesC lookupTarget
+    )
+  => Eq (KeyLookupResult lookupTarget)
+
+deriving instance
+    ( Show a, a ~ MissingC lookupTarget
+    , Show b, b ~ DefaultsC lookupTarget
+    , Show c, c ~ SourcesC lookupTarget
+    )
+  => Show (KeyLookupResult lookupTarget)
 
 -- | The type for creating a source given a 'Config', some sources require a
 -- certain configuration to be initialized (for example: the redis source

--- a/packages/conferer/src/Conferer/FromConfig.hs
+++ b/packages/conferer/src/Conferer/FromConfig.hs
@@ -31,13 +31,15 @@ module Conferer.FromConfig
   , (/.)
   , File(..)
   , KeyLookupResult(..)
+  , LookupTarget(..)
   , OverrideFromConfig(..)
   , overrideFetch
-
-  , fetchFromDefaults
-  , fetchRequiredFromDefaults
+  , getKeyFromSources
+  , getKeyFromDefaults
+  , getKey
   ) where
 
 import Conferer.FromConfig.Internal
 import Conferer.Config.Internal.Types
+import Conferer.Config.Internal
 import Conferer.Key

--- a/packages/conferer/test/Conferer/FromConfig/ListSpec.hs
+++ b/packages/conferer/test/Conferer/FromConfig/ListSpec.hs
@@ -165,7 +165,7 @@ spec = do
       ensureFetchParses
         @[[Int]]
         [ ("1.0", "0")
+        , ("prototype.1", "8")
         ]
-        [ ("prototype.1", toDyn @Int 8)
-        ]
+        [ ]
         [[0, 8]]


### PR DESCRIPTION
# Description

This doesn't add feature but it changes the shape of `KeyLookupResult` to make it easy to work with in preparation
to fixing #51.

Specifically this:

* Expose two functions `getKeyFromDefaults` and `getKeyFromSources` to get a value directly from those sources instead of
    relying on the cascading of `getKey`.
* Changes the shape of `KeyLookupResult` (not backward compatible) to express more invariants like:
  * getting a key from sources can never get a `FoundKeyInDefaults` and viceversa
  * you may always get a MissingKey
* `listSubkeys` not doesn't quite make sense since getKey needs a type and only having a value in dynamics doesn't mean
  that it has the right type, so now it only listSubkeys set by `Source` but not if they are set by defaults

Fixes #(issue)

# Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added changes to the relevant changelog
- [ ] I have made corresponding changes to the documentation
- [ ] I have added haddock comments for every new function and data
