### PR TITLE
Sync `FromConfig` with latest version of hspec Settings

### DIFF
--- a/docs/fromConfig/hspec.md
+++ b/docs/fromConfig/hspec.md
@@ -132,10 +132,18 @@ Show colorized diffs.
 
 Default: `True`
 
-### `formatter :: Maybe Formatter` (NOT CONFIGURABLE BY THE USER)
+### `formatter :: Maybe Formatter`
 
 Formatter for test results, Nothing means using the default
 formatter.
+
+* `silent`: Hide details from each test and only print summary
+* `specdoc`: Show all test names in a hierarchical structure colored acording
+  to test results
+* `progress`: Show dots as tests progress
+* `failed-examples`: Only show list of failed tests
+* `checks`: Show all test names in a hierarchical structure using unicode
+  checks for test results (requires `hspec >= 2.7.10`).
 
 Default: `Nothing`
 
@@ -156,3 +164,9 @@ Default: `Left stdout`
 Number of concurrent jobs to use, Nothing means numbers of cpus
 
 Default: `Nothing`
+
+### `randomize :: Bool`
+
+Number of concurrent jobs to use, Nothing means numbers of cpus
+
+Default: `False`

--- a/packages/hspec/CHANGELOG.md
+++ b/packages/hspec/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [PVP](https://pvp.haskell.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+* Added all defaults for now the FromConfig instance actually works
+
 ### Changed
 
 * `"checks"` is a valid value for `formatter` key (with `hspec >= 2.7.10`)

--- a/packages/hspec/CHANGELOG.md
+++ b/packages/hspec/CHANGELOG.md
@@ -6,7 +6,14 @@ and this project adheres to [PVP](https://pvp.haskell.org/).
 
 ## [Unreleased]
 
-Nothing
+### Changed
+
+* `"checks"` is a valid value for `formatter` key (with `hspec >= 2.7.10`)
+* `failed-examples` is a valid value for `formatter`
+
+### Added
+
+* `randomize` key is used for configuring `configRandomize`
 
 ## [v1.1.0.0] 2021-03-07
 

--- a/packages/hspec/conferer-hspec.cabal
+++ b/packages/hspec/conferer-hspec.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a835205aab15434694f7fdedf781e2137c3bb5affebfc6defffa635afa77b428
+-- hash: e5e73d957fe579748733c3461beadbbe190c9c4cbe011a88e38870a23502fbac
 
 name:           conferer-hspec
 version:        1.1.0.0
@@ -47,6 +47,7 @@ test-suite specs
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Conferer.FromConfig.HspecSpec
       Paths_conferer_hspec
   hs-source-dirs:
       test

--- a/packages/hspec/src/Conferer/FromConfig/Hspec.hs
+++ b/packages/hspec/src/Conferer/FromConfig/Hspec.hs
@@ -33,8 +33,12 @@ instance FromConfig Hspec.Formatter where
     fetchFromConfigWith $
     (\case
       "silent" -> Just Hspec.silent
+#if MIN_VERSION_hspec_core(2,7,10)
+      "checks" -> Just Hspec.checks
+#endif
       "specdoc" -> Just Hspec.specdoc
       "progress" -> Just Hspec.progress
+      "failed-examples" -> Just Hspec.failed_examples
       "failed_examples" -> Just Hspec.failed_examples
       _ -> Nothing
     ) . toLower
@@ -75,6 +79,9 @@ desconstructHspecConfigToDefaults Hspec.Config{..} =
   , ("focusedOnly", toDyn configFocusedOnly)
   , ("failOnFocused", toDyn configFailOnFocused)
 #endif
+#if MIN_VERSION_hspec_core(2,7,3)
+  , ("randomize", toDyn configRandomize)
+#endif
   ]
 
 instance FromConfig Hspec.Config where
@@ -114,5 +121,8 @@ instance FromConfig Hspec.Config where
 #if MIN_VERSION_hspec_core(2,7,0)
     configFocusedOnly <- fetchFromConfig (key /. "focusedOnly") config
     configFailOnFocused <- fetchFromConfig (key /. "failOnFocused") config
+#endif
+#if MIN_VERSION_hspec_core(2,7,3)
+    configRandomize <- fetchFromConfig (key /. "randomize") config
 #endif
     pure Hspec.Config{..}

--- a/packages/hspec/src/Conferer/FromConfig/Hspec.hs
+++ b/packages/hspec/src/Conferer/FromConfig/Hspec.hs
@@ -61,6 +61,8 @@ desconstructHspecConfigToDefaults Hspec.Config{..} =
   , ("colorMode", toDyn configColorMode)
   , ("htmlOutput", toDyn configHtmlOutput)
   , ("formatter", toDyn configFormatter)
+  , ("rerunAllOnSuccess", toDyn configRerunAllOnSuccess)
+  , ("outputFile", toDyn configOutputFile)
 #if MIN_VERSION_hspec_core(2,1,1)
   , ("skipPredicate", toDyn configSkipPredicate)
 #endif

--- a/packages/hspec/test/Conferer/FromConfig/HspecSpec.hs
+++ b/packages/hspec/test/Conferer/FromConfig/HspecSpec.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE TypeApplications #-}
+module Conferer.FromConfig.HspecSpec where
+
+import Test.Hspec
+import qualified Test.Hspec.Core.Runner as Hspec
+
+import Conferer
+import Conferer.Test
+import Conferer.FromConfig.Hspec ()
+
+spec :: Spec
+spec = do
+  describe "with an empty config" $ do
+    it "throws an exception" $ do
+      config <- configWith [] []
+      unsafeFetchKey @Hspec.Config config "warp"
+        `shouldThrow` anyException
+  describe "a config that has a default" $ do
+    it "doesn't throw" $ do
+      config <- configWith [] []
+      _ <- fetchKey @Hspec.Config config "hspec" configDef
+      return ()


### PR DESCRIPTION
# Description

Right now for there are a couple of changes that conferer-hspec is not taking into consideration:

## New formatter: `checks`

expected: settings `formatter=checks` uses the `Hspec.checks` formatter
current behavior: Parsing of option simply fails

## New setting `configRandomize`

expected: setting `randomize=true` randomizes the run of the tests
current behavior: it's ignored

## Add `failed-examples`

Alias of `failed_examples` for `formatter` since the original uses kebab-case

Fixes #(issue)

# Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added changes to the relevant changelog
- [x] I have made corresponding changes to the documentation
- [x] I have added haddock comments for every new function and data
