### PR TITLE
Fix clashing module names to allow loading everything at once

### DIFF
--- a/example/package.yaml
+++ b/example/package.yaml
@@ -6,6 +6,7 @@ maintainer: lucas6246@gmail.com
 _common/lib: !include ../utils/package.common.yaml
 
 <<: *ghcoptions
+<<: *extensions
 
 dependencies:
 - base >= 4.7 && < 5

--- a/example/src/AnnouncementBlogpost.hs
+++ b/example/src/AnnouncementBlogpost.hs
@@ -33,8 +33,8 @@ mkMyConfig = Conferer.mkConfig' []
   ]
 
 
-main :: IO ()
-main = do
+announcementMain :: IO ()
+announcementMain = do
   config <- mkMyConfig
   appConfig <- Conferer.fetch config
   let warpSettings = appConfigServer appConfig

--- a/packages/aeson/conferer-aeson.cabal
+++ b/packages/aeson/conferer-aeson.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d73d44df61f4d56a6aa0b89b1ce6a27123ce674091a311ce30c992d64be6ef56
+-- hash: a277c3aeb83a24c25a9b3314660add906a9c3a3420bee5b7b13a1f244a3f0210
 
 name:           conferer-aeson
 version:        1.1.0.1
@@ -50,7 +50,7 @@ library
 
 test-suite specs
   type: exitcode-stdio-1.0
-  main-is: Spec.hs
+  main-is: ConfererAesonSpecMain.hs
   other-modules:
       Conferer.FromConfig.AesonSpec
       Conferer.Source.AesonSpec
@@ -58,7 +58,7 @@ test-suite specs
   hs-source-dirs:
       test
   default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
-  ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
+  ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererAesonSpecMain
   build-depends:
       aeson >=0.10 && <2.0
     , aeson-qq

--- a/packages/aeson/package.yaml
+++ b/packages/aeson/package.yaml
@@ -24,7 +24,7 @@ dependencies:
 
 tests:
   specs:
-    main: Spec.hs
+    main: ConfererAesonSpecMain
     source-dirs: test
     dependencies:
     - conferer

--- a/packages/aeson/test/ConfererAesonSpecMain.hs
+++ b/packages/aeson/test/ConfererAesonSpecMain.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=ConfererAesonSpecMain #-}

--- a/packages/aeson/test/Spec.hs
+++ b/packages/aeson/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/packages/conferer/conferer.cabal
+++ b/packages/conferer/conferer.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 084c6c8b533a377150d071cd8bdebe036310b369eb6d2edeeb57a01dab0b2b03
+-- hash: ff270bcc4d8154db08adc97727d49c5f1f9a4b1399dfac9ef714617d097a2500
 
 name:           conferer
 version:        1.1.0.0
@@ -84,7 +84,6 @@ test-suite specs
       Conferer.Source.NullSpec
       Conferer.Source.PropertiesFileSpec
       ConfererSpec
-      Spec
       Paths_conferer
   hs-source-dirs:
       test

--- a/packages/conferer/test/ConfererSpecMain.hs
+++ b/packages/conferer/test/ConfererSpecMain.hs
@@ -1,7 +1,1 @@
-module ConfererSpecMain where
-
-import Test.Hspec.Runner
-import qualified Spec
-
-main :: IO ()
-main = hspecWith defaultConfig Spec.spec
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=ConfererSpecMain #-}

--- a/packages/conferer/test/Spec.hs
+++ b/packages/conferer/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/packages/dhall/conferer-dhall.cabal
+++ b/packages/dhall/conferer-dhall.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5369decf9ec97f09aa583b969569ecc0431705a5d0f1fdf188b0ca5d1a82c73a
+-- hash: e7a6894c4340463874ee057abfcf3dde4b94bb05618151c6850f6807ef85fc7d
 
 name:           conferer-dhall
 version:        1.1.0.0
@@ -49,13 +49,13 @@ library
 
 test-suite specs
   type: exitcode-stdio-1.0
-  main-is: Spec.hs
+  main-is: ConfererDhallSpecMain.hs
   other-modules:
       Paths_conferer_dhall
   hs-source-dirs:
       test
   default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
-  ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
+  ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererDhallSpecMain
   build-depends:
       base >=4.3 && <5
     , bytestring >=0.10 && <0.11

--- a/packages/dhall/package.yaml
+++ b/packages/dhall/package.yaml
@@ -21,8 +21,8 @@ dependencies:
 
 tests:
   specs:
-    main:                Spec.hs
-    source-dirs:         test
+    main: ConfererDhallSpecMain
+    source-dirs: test
     dependencies:
     - conferer-dhall
     - hspec

--- a/packages/dhall/test/ConfererDhallSpecMain.hs
+++ b/packages/dhall/test/ConfererDhallSpecMain.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=ConfererDhallSpecMain #-}

--- a/packages/dhall/test/Spec.hs
+++ b/packages/dhall/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/packages/hedis/conferer-hedis.cabal
+++ b/packages/hedis/conferer-hedis.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 571d338f5e8a710df4b1716c5df0d13146782ea9cdc5f655763e8faca9b77384
+-- hash: ce68464a13b964af2188b07e120c298253aa39bde0d8674cd30517b9a67fb552
 
 name:           conferer-hedis
 version:        1.1.0.0
@@ -45,14 +45,14 @@ library
 
 test-suite specs
   type: exitcode-stdio-1.0
-  main-is: Spec.hs
+  main-is: ConfererHedisSpecMain.hs
   other-modules:
       Conferer.FromConfig.HedisSpec
       Paths_conferer_hedis
   hs-source-dirs:
       test
   default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
-  ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
+  ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererHedisSpecMain
   build-depends:
       base >=4.3 && <5
     , conferer >=1.1.0.0 && <2.0.0.0

--- a/packages/hedis/package.yaml
+++ b/packages/hedis/package.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 tests:
   specs:
-    main: Spec.hs
+    main: ConfererHedisSpecMain
     source-dirs: test
     dependencies:
     - conferer-hedis

--- a/packages/hedis/test/ConfererHedisSpecMain.hs
+++ b/packages/hedis/test/ConfererHedisSpecMain.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=ConfererHedisSpecMain #-}

--- a/packages/hedis/test/Spec.hs
+++ b/packages/hedis/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/packages/hspec/conferer-hspec.cabal
+++ b/packages/hspec/conferer-hspec.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e5e73d957fe579748733c3461beadbbe190c9c4cbe011a88e38870a23502fbac
+-- hash: 8cbf05cd31a3fd9b301a9a87b6e16d4f7486b6aa5fee691717675911833ab6a1
 
 name:           conferer-hspec
 version:        1.1.0.0
@@ -45,14 +45,14 @@ library
 
 test-suite specs
   type: exitcode-stdio-1.0
-  main-is: Spec.hs
+  main-is: ConfererHspecSpecMain.hs
   other-modules:
       Conferer.FromConfig.HspecSpec
       Paths_conferer_hspec
   hs-source-dirs:
       test
   default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
-  ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
+  ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererHspecSpecMain
   build-depends:
       base >=4.3 && <5
     , conferer >=1.1.0.0 && <2.0.0.0

--- a/packages/hspec/package.yaml
+++ b/packages/hspec/package.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 tests:
   specs:
-    main: Spec.hs
+    main: ConfererHspecSpecMain
     source-dirs: test
     dependencies:
     - conferer-hspec

--- a/packages/hspec/test/ConfererHspecSpecMain.hs
+++ b/packages/hspec/test/ConfererHspecSpecMain.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=ConfererHspecSpecMain #-}

--- a/packages/hspec/test/Spec.hs
+++ b/packages/hspec/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/packages/snap/conferer-snap.cabal
+++ b/packages/snap/conferer-snap.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f24c08f79b9b3fd928adaebe450f764b3c546dd5fe48f6d23f52e1174706c0df
+-- hash: 5d4c8a222d0ba1f283daf6c54c3271298776195e55ecc6c1a0db2e62ba7e4484
 
 name:           conferer-snap
 version:        1.0.0.0
@@ -46,14 +46,14 @@ library
 
 test-suite specs
   type: exitcode-stdio-1.0
-  main-is: Spec.hs
+  main-is: ConfererSnapSpecMain.hs
   other-modules:
       Conferer.FromConfig.SnapSpec
       Paths_conferer_snap
   hs-source-dirs:
       test
   default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
-  ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
+  ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererSnapSpecMain
   build-depends:
       base >=4.3 && <5
     , conferer >=1.1.0.0 && <2.0.0.0

--- a/packages/snap/package.yaml
+++ b/packages/snap/package.yaml
@@ -18,8 +18,8 @@ dependencies:
 
 tests:
   specs:
-    main:                Spec.hs
-    source-dirs:         test
+    main: ConfererSnapSpecMain
+    source-dirs: test
     dependencies:
     - conferer-snap
     - hspec

--- a/packages/snap/test/ConfererSnapSpecMain.hs
+++ b/packages/snap/test/ConfererSnapSpecMain.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=ConfererSnapSpecMain #-}

--- a/packages/snap/test/Spec.hs
+++ b/packages/snap/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/packages/warp/conferer-warp.cabal
+++ b/packages/warp/conferer-warp.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b2637a0bc44386b75c871b4c995b686ead11f39ca09358dac995fb40f8254ae1
+-- hash: df73f5f80e54466703aced50513b638f4bc33dc0331ba7874c4370b0f032207e
 
 name:           conferer-warp
 version:        1.1.0.0
@@ -47,14 +47,14 @@ library
 
 test-suite specs
   type: exitcode-stdio-1.0
-  main-is: Spec.hs
+  main-is: ConfererWarpSpecMain.hs
   other-modules:
       Conferer.FromConfig.WarpSpec
       Paths_conferer_warp
   hs-source-dirs:
       test
   default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
-  ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
+  ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererWarpSpecMain
   build-depends:
       base >=4.3 && <5
     , conferer >=1.1.0.0 && <2.0.0.0

--- a/packages/warp/package.yaml
+++ b/packages/warp/package.yaml
@@ -19,8 +19,8 @@ dependencies:
 
 tests:
   specs:
-    main:                Spec.hs
-    source-dirs:         test
+    main: ConfererWarpSpecMain
+    source-dirs: test
     dependencies:
     - conferer-warp
     - hspec

--- a/packages/warp/test/ConfererWarpSpecMain.hs
+++ b/packages/warp/test/ConfererWarpSpecMain.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=ConfererWarpSpecMain #-}

--- a/packages/warp/test/Spec.hs
+++ b/packages/warp/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/packages/yaml/conferer-yaml.cabal
+++ b/packages/yaml/conferer-yaml.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 236d302e99d12096c87a3a2e9b5213d81885b3545ada73941a284528324ecb92
+-- hash: 74c5b092926dae6975cbd2a510874b1160e2686cb938d560803691c967fa3094
 
 name:           conferer-yaml
 version:        1.1.0.0
@@ -45,13 +45,13 @@ library
 
 test-suite specs
   type: exitcode-stdio-1.0
-  main-is: Spec.hs
+  main-is: ConfererYamlSpecMain.hs
   other-modules:
       Paths_conferer_yaml
   hs-source-dirs:
       test
   default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
-  ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
+  ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererYamlSpecMain
   build-depends:
       base >=4.3 && <5
     , conferer >=1.1.0.0 && <2.0.0.0

--- a/packages/yaml/package.yaml
+++ b/packages/yaml/package.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 tests:
   specs:
-    main: Spec.hs
+    main: ConfererYamlSpecMain
     source-dirs: test
     dependencies:
     - conferer-yaml

--- a/packages/yaml/test/ConfererYamlSpecMain.hs
+++ b/packages/yaml/test/ConfererYamlSpecMain.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=ConfererYamlSpecMain #-}

--- a/packages/yaml/test/Spec.hs
+++ b/packages/yaml/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
# Description

Change names for the tests for that we can do `stack repl` without clashing `Spec.hs` modules.

Fixes #(issue)

# Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added changes to the relevant changelog
- [x] I have made corresponding changes to the documentation
- [x] I have added haddock comments for every new function and data
