### PR TITLE
Avoid talking about keys when reporting errors

### DIFF
--- a/packages/aeson/CHANGELOG.md
+++ b/packages/aeson/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [PVP](https://pvp.haskell.org/).
 
 ## [Unreleased]
 
-Nothing
+### Changed
+
+* More strict parser for the json value:
+  - Disallow invalid keys with a clear error message
+  - Disallow using objects or arrays in the `_self` special key
 
 ## [v1.1.0.1] 2021-03-14
 

--- a/packages/aeson/src/Conferer/FromConfig/Aeson.hs
+++ b/packages/aeson/src/Conferer/FromConfig/Aeson.hs
@@ -13,14 +13,7 @@ module Conferer.FromConfig.Aeson where
 import Data.Aeson
 
 import Conferer.FromConfig
-import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 
 instance FromConfig Value where
-  fromConfig key config = do
-    rawAeson <- fetchFromConfig @Text key config
-    case eitherDecodeStrict' @Value $ Text.encodeUtf8 rawAeson of
-      Right value -> 
-        return value
-      Left _ -> 
-        throwConfigParsingError @Value key rawAeson
+  fromConfig = fetchFromConfigWith (decodeStrict' . Text.encodeUtf8)

--- a/packages/aeson/src/Conferer/Source/Aeson.hs
+++ b/packages/aeson/src/Conferer/Source/Aeson.hs
@@ -10,13 +10,12 @@
 module Conferer.Source.Aeson where
 
 import Data.Aeson
-import Control.Applicative
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-import Data.Vector ((!?))
+import Data.Vector (Vector, (!?))
 import qualified Data.Vector as Vector
 import Text.Read (readMaybe)
 import qualified Data.ByteString as B
@@ -24,27 +23,76 @@ import qualified Data.ByteString.Lazy as L
 import Data.List
 import System.Directory
 import Control.Exception
-import Control.Monad (guard)
+import Control.Monad (unless, forM)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 
 import Conferer.Source.Files
 import qualified Conferer.Source.Null as Null
 import Conferer.Source
+import Data.Maybe
 
 -- | 'Source' that read a config file as json and uses that value in a way that
 -- makes sense for Conferer but doesn't respect json perfectly.
 data JsonSource = JsonSource
-  { value :: Value
+  { value :: ValueIR
   , filepath :: FilePath
   } deriving (Show, Eq)
 
+type RawKey = [Text]
+
+-- | This is the representation of the 'explainNotFound', this is useful
+-- for sources which are not actually json but are isomorphic with json
+-- like dhall or yaml.
+data FindKeyInValueResult
+  = Missing
+      RawKey
+      -- ^ The path that right now is present in the actual config
+      RawKey
+      -- ^ The path that is missing in the object
+      ValueIR
+      -- ^ The current value that is present in the config
+  | Found
+      RawKey
+      -- ^ The true json path where the key was found
+      Text
+      -- ^ The textual representation of the value
+      ValueIR
+      -- ^ The original json value that we found
+  deriving (Eq, Show)
+
 instance IsSource JsonSource where
   getKeyInSource JsonSource {..} key = do
-    return $ valueToText =<< traverseJSON key value
+    case findKeyInsideValue key value of
+      Found _ t _ -> return $ Just t
+      _ -> return Nothing
+
   getSubkeysInSource JsonSource {..} key = do
-    return $ fmap (key /.) $ maybe [] listKeysInJSON $ traverseJSON key value
+    let deepestValueFound = traverseJSON key value
+        foundKey = valueIRKey deepestValueFound
+    if foundKey == key
+      then do
+        pure $ listKeysInJSON deepestValueFound
+      else do
+        pure []
+
   explainNotFound JsonSource {..} key  =
-    renderExplainForAeson filepath $ getNoKeyExplainResult key value
+    case findKeyInsideValue key value of
+      Missing existingPath nonExistingPath v ->
+        "Replacing " ++
+        showRawKeyAsTarget existingPath ++
+        " from '" ++
+        valueIR2String v ++
+        "' to '" ++
+        valueIR2String (setKey "some value" nonExistingPath v) ++
+        "' on file '" ++ filepath ++ "'"
+      result@Found {} ->
+        error $ "Getting an non existant key returned that it exists, \
+                \that is a bug in conferer, please report it at \
+                \https://github.com/ludat/conferer/issues with :\n " ++ show result
+    where
+      showRawKeyAsTarget :: RawKey -> String
+      showRawKeyAsTarget [] = "the whole json"
+      showRawKeyAsTarget k = "the value at '" ++ showRawKey k ++ "'"
   explainSettedKey JsonSource {..} key =
     concat
     [ "json key '"
@@ -54,133 +102,208 @@ instance IsSource JsonSource where
     , "'"
     ]
     where
-      getRealRawKey :: Key -> Value -> RawKey
+      getRealRawKey :: Key -> ValueIR -> RawKey
       getRealRawKey k originalValue =
-        case getNoKeyExplainResult k originalValue of
-          FoundIn rawKey -> rawKey
-          result@(MissingKeyInPlainObject _ _ _) ->
+        case findKeyInsideValue k originalValue of
+          Found rawKey _ _ -> rawKey
+          result ->
             error $ "Getting an existing key returned that it doesn't exist, \
                     \that is a bug in conferer, please report it at \
                     \https://github.com/ludat/conferer/issues with :\n " ++ show result
 
-renderExplainForAeson :: FilePath -> ExplainResult -> String
-renderExplainForAeson filepath e =
-  case e of
-    MissingKeyInPlainObject existingPath nonExistingPath v ->
-      "Replacing " ++
-      showRawKeyAsTarget existingPath ++
-      " from '" ++
-      value2String v ++
-      "' to '" ++
-      value2String (merge v $ objectFromPath nonExistingPath (String "some value")) ++
-      "' on file '" ++ filepath ++ "'"
-    result@(FoundIn _) ->
-      error $ "Getting an non existant key returned that it exists, \
-              \that is a bug in conferer, please report it at \
-              \https://github.com/ludat/conferer/issues with :\n " ++ show result
+
+setKey :: Text -> RawKey -> ValueIR -> ValueIR
+setKey newText = go
   where
-    showRawKeyAsTarget :: RawKey -> String
-    showRawKeyAsTarget [] = "the whole json"
-    showRawKeyAsTarget k = "the value at '" ++ showRawKey k ++ "'"
+  newValue = String newText
+  go :: RawKey -> ValueIR -> ValueIR
+  go [] (ObjectIR key _ o) =
+    if HashMap.null o
+      then RawValue key newText newValue
+      else ObjectIR key (Just (newText, newValue)) o
+  go (k:ks) (ObjectIR key v o) = ObjectIR key v $ HashMap.alter
+    (\case
+      Just oldIR -> Just $ go ks oldIR
+      Nothing -> Just $ go ks (ObjectIR (key /. fromText k) Nothing HashMap.empty)
+    ) k o
 
-merge :: Value -> Value -> Value
-merge v1 v2 =
-  let o1 = value2map v1
-      o2 = value2map v2
-      newO = HashMap.union o1 o2
-  in
-    -- If the new object only has "_self" key we can replace it with the contents
-    -- of self
-    case (HashMap.size newO, HashMap.lookup "_self" newO) of
-      (1, Just v) -> v
-      _ -> Object newO
-  where
-    value2map :: Value -> HashMap Text Value
-    value2map (Object o) = o
-    value2map (Array v) =
-      HashMap.fromList $ zip (fmap (Text.pack . show @Integer) [0..]) $ Vector.toList v
-    value2map v = HashMap.singleton "_self" v
+  go [] (RawValue key _ _) = RawValue key newText newValue
+  go (k:ks) (RawValue key t v) =
+    ObjectIR key (Just (t, v)) $ HashMap.singleton k $ go ks $ ObjectIR (key /. fromText k) Nothing HashMap.empty
 
+  go [] (ArrayIR key vs) =
+    if Vector.null vs
+      then RawValue key newText newValue
+      else ObjectIR key (Just (newText, newValue)) $ list2object vs
+  go (k:ks) (ArrayIR key vs) =
+    case readMaybe @Int $ Text.unpack k of
+      Just n | isJust $ vs !? n ->
+        ArrayIR key $ Vector.imap (\i v -> if i == n then go ks v else v) vs
+      _ ->
+        ObjectIR key Nothing $
+          HashMap.insert k (go ks (ObjectIR (key /. fromText k) Nothing HashMap.empty)) $ list2object vs
 
-objectFromPath :: RawKey -> Value -> Value
-objectFromPath [] content = content
-objectFromPath (k:ks) content =
-  Object $ HashMap.fromList [(k, objectFromPath ks content)]
+  list2object = HashMap.fromList . zip (fmap (Text.pack . show @Integer) [0..]) . Vector.toList
 
 -- | Utility function to show a 'Value'
 value2String :: Value -> String
 value2String = LBS.unpack . encode
 
+valueIR2String :: ValueIR -> String
+valueIR2String = value2String . valueIR2Value
+
+valueIRRawKey :: ValueIR -> RawKey
+valueIRRawKey = rawKeyComponents . valueIRKey
+
+valueIRKey :: ValueIR -> Key
+valueIRKey (RawValue k _ _) = k
+valueIRKey (ArrayIR k _) = k
+valueIRKey (ObjectIR k _ _) = k
+
+valueIR2Value :: ValueIR -> Value
+valueIR2Value = go
+  where
+  go :: ValueIR -> Value
+  go (RawValue _ _ v) = v
+  go (ArrayIR _ vs) = Array $ fmap go vs
+  go (ObjectIR _ j o) =
+    let
+      initialMap =
+        case j of
+          Just (_, v) -> HashMap.singleton "_self" v
+          Nothing -> HashMap.empty
+
+    in Object $ HashMap.union initialMap (fmap go o)
+
 -- | Utility function to show a raw key to the user
 showRawKey :: RawKey -> String
-showRawKey rawKey =
-  (intercalate "." $ fmap Text.unpack $ rawKey)
+showRawKey =
+  intercalate "." . fmap Text.unpack
 
--- | This is the representation of the 'explainNotFound', this is useful
--- for sources which are not actually json but are isomorphic with json
--- like dhall or yaml.
-data ExplainResult
-  = MissingKeyInPlainObject
-      RawKey
-      -- ^ The path that right now is present in the actual config
-      RawKey
-      -- ^ The path that is missing in the object
-      Value
-      -- ^ The current value that is present in the config
-  | FoundIn RawKey
-  deriving (Eq)
+findKeyInsideValue :: Key -> ValueIR -> FindKeyInValueResult
+findKeyInsideValue key aValue =
+  let
+    deepestValueFound = traverseJSON key aValue
+    deepestKey = valueIRKey deepestValueFound
+  in
+    case (stripKeyPrefix deepestKey key, deepestValueFound) of
+      (Just "keys", ObjectIR _ _ o) ->
+        let generatedKeys =
+              mconcat $
+              intersperse "," $
+              sort $
+              HashMap.keys o
+        in Found (rawKeyComponents key) generatedKeys deepestValueFound
 
-instance Show ExplainResult where
-  show (MissingKeyInPlainObject alreadyPresentPath missingPath currentValue) =
-    intercalate " "
-      [ "MissingKeyInPlainObject"
-      , show alreadyPresentPath
-      , show missingPath
-      , "[aesonQQ|" ++ value2String currentValue ++ "|]"
-      ]
-  show (FoundIn rawKey) =
-    intercalate " "
-      [ "MissingKeyInPlainObject"
-      , show rawKey
-      ]
+      (Just "keys", ArrayIR _ vs) ->
+        let
+          generatedKeys =
+            mconcat $
+            intersperse "," $
+            fmap (Text.pack . show)
+            [0..length vs - 1]
+        in Found (rawKeyComponents key) generatedKeys deepestValueFound
 
-getNoKeyExplainResult :: Key -> Value -> ExplainResult
-getNoKeyExplainResult key value = go ([], rawKeyComponents key) value
+      (Just "", ObjectIR _ maybeSelf _) ->
+        case maybeSelf of
+          Just (t, _) ->
+            Found (rawKeyComponents key ++ ["_self"]) t deepestValueFound
+          Nothing ->
+            Missing (rawKeyComponents key) [] deepestValueFound
+
+      (Just "", ArrayIR _ _) ->
+        Missing (rawKeyComponents key) [] deepestValueFound
+
+      (Just "", RawValue _ t _) ->
+        Found (rawKeyComponents key) t deepestValueFound
+
+      (Just k, _) ->
+        Missing (rawKeyComponents deepestKey) (rawKeyComponents k) deepestValueFound
+
+      (Nothing, _) ->
+        error $
+          unlines
+            [ "The impossible happened: deepestKey must be a suffix of key since \
+              \one generates the other."
+            , ""
+            , "deepestKey: " ++ show deepestKey
+            , "key: " ++ show key
+            , "value: " ++ show aValue
+            ]
+
+
+-- | Internal Repepresentation of a json value that matches the way we find keys
+-- so concrete values are translated into a single constructor and the special
+-- "_self" key is descriminated, and also each node contains its 'Key'
+data ValueIR
+  = ArrayIR
+    -- ^ Repesentation of an array
+    Key
+    -- ^ path inside the original json
+    (Vector ValueIR)
+    -- ^ inner values
+  | ObjectIR
+    -- ^ Repesentation of an object
+    Key
+    -- ^ path inside the original json
+    (Maybe (Text, Value))
+    -- ^ "_self" key value, with the textual representation and the original value
+    (HashMap Text ValueIR)
+    -- ^ inner values (these Text are all valid key fragments)
+  | RawValue Key Text Value
+  deriving (Eq, Show)
+
+parseValue :: Value -> Either ProblemWithJSON ValueIR
+parseValue = go ""
   where
-    go :: (RawKey, RawKey) -> Value -> ExplainResult
-    go (visitedKeys, []) v@(Object o) =
-      case HashMap.lookup "_self" o of
-        Just innerValue@(Object _) ->
-          MissingKeyInPlainObject (visitedKeys ++ ["_self"]) [] innerValue
+  go key (Object o) = do
+    let
+      (validKeys, invalidKeys) = partition (isValidKeyFragment . fst)
+        $ HashMap.toList
+        $ HashMap.delete "_self" o
+    unless (null invalidKeys) $
+      Left $ InvalidKey (rawKeyComponents key) (fst $ head invalidKeys)
+    self <- sequence $ parseSelf key <$> HashMap.lookup "_self" o
+    content <- forM validKeys $ \(k, v) -> do
+      let currentKey = key /. fromText k
+      inner <- go currentKey v
+      pure (k, inner)
+    Right $ ObjectIR key self $ HashMap.fromList content
 
-        Just innerValue@(Array _) ->
-          MissingKeyInPlainObject (visitedKeys ++ ["_self"]) [] innerValue
+  go key (Array as) = do
+    content <- forM (Vector.indexed as) $ \(i, v) -> do
+      let
+        k = Text.pack $ show i
+        currentKey = key /. fromText k
+      go currentKey v
+    Right $ ArrayIR key content
 
-        Just _v -> FoundIn (visitedKeys ++ ["_self"])
+  go key v@(Bool b) =
+    Right $ RawValue key (boolToString b) v
 
-        Nothing ->
-          MissingKeyInPlainObject visitedKeys [] v
+  go key v@(Number n) =
+    Right $ RawValue key (numberToString n) v
 
-    go (visitedKeys, []) v@(Array _) = MissingKeyInPlainObject visitedKeys [] v
-    go (visitedKeys, []) _v = FoundIn visitedKeys
-    go (visitedKeys, k:ks) v =
-      case v of
-        (Object o) ->
-          case HashMap.lookup k o of
-            Nothing -> MissingKeyInPlainObject visitedKeys (k:ks) v
-            (Just x) -> go (visitedKeys ++ [k], ks) x
-        (Array vs) ->
-          case readMaybe $ Text.unpack k of
-            Nothing -> MissingKeyInPlainObject visitedKeys (k:ks) v
-            Just (n :: Int) ->
-              case vs !? n of
-                Nothing ->
-                  MissingKeyInPlainObject visitedKeys (k:ks) v
-                Just innerV ->
-                  go (visitedKeys ++ [k], ks) innerV
+  go key v@Null =
+    Right $ RawValue key "null" v
 
-        _ ->
-          MissingKeyInPlainObject visitedKeys (k:ks) v
+  go key v@(String s) =
+    Right $ RawValue key s v
+
+  parseSelf :: Key -> Value -> Either ProblemWithJSON (Text, Value)
+  parseSelf k v =
+    case v of
+      (String t) -> Right (t, v)
+      (Object _) -> Left $ InvalidSelfValue (rawKeyComponents k) v
+      (Array _) -> Left $ InvalidSelfValue (rawKeyComponents k) v
+      (Number n) -> Right (numberToString n, v)
+      (Bool b) -> Right (boolToString b, v)
+      Null -> Right ("null", v)
+
+  boolToString True = "true"
+  boolToString False = "false"
+
+  numberToString = Text.decodeUtf8 . L.toStrict . encode . Number
 
 -- | Create a 'SourceCreator' which uses files with @config/{env}.json@
 -- template and then uses 'fromFilePath'
@@ -209,16 +332,12 @@ fromFilePath' relativeFilePath = do
   fileExists <- doesFileExist fileToParse
   if fileExists
     then do
-      value <- decodeStrict' <$> B.readFile fileToParse
-      case value of
+      decodeStrict' <$> B.readFile fileToParse
+      >>= \case
         Nothing ->
           error $ "Failed to decode json file '" ++ fileToParse ++ "'"
         Just v -> do
-          case invalidJsonKeys v of
-            [] ->
-              return $ fromValue fileToParse v
-            errors ->
-              throwIO $ JsonHasInvalidKeysError fileToParse errors
+          fromValue fileToParse v
     else do
       return $ Source $ Null.NullSource
         { nullExplainNotFound = \key ->
@@ -226,144 +345,78 @@ fromFilePath' relativeFilePath = do
           [ "Creating a file '"
           , fileToParse
           , "' (it doesn't exist now) with the object '"
-          , value2String $ objectFromPath
+          , valueIR2String $ setKey "some text"
               (rawKeyComponents key)
-              (String "some value")
+              emptyRootObject
           , "'"
           ]
         }
 
+emptyRootObject :: ValueIR
+emptyRootObject = ObjectIR "" Nothing HashMap.empty
+
 -- | Exception thrown from 'fromFilePath' when the json in the
 -- parsed file has incorrect keys
-data JsonHasInvalidKeysError =
-  JsonHasInvalidKeysError FilePath [RawKey] deriving (Eq, Show)
+data InvalidJSONError =
+  InvalidJSONError FilePath ProblemWithJSON
+  deriving (Eq, Show)
 
-instance Exception JsonHasInvalidKeysError
+data ProblemWithJSON
+  = InvalidKey RawKey Text
+  | InvalidSelfValue RawKey Value
+  deriving (Eq, Show)
+
+instance Exception InvalidJSONError
 
 -- | Create a 'Source' from a json value, never fails.
-fromValue :: FilePath -> Value -> Source
-fromValue filepath value =
-  Source JsonSource {..}
+fromValue :: FilePath -> Value -> IO Source
+fromValue filepath rawValue =
+  case fromValue' filepath rawValue of
+    Right s ->
+      pure s
+    Left e ->
+      throwIO $ InvalidJSONError filepath e
 
--- | Traverse a 'Value' using a 'Key' to get a 'Value'.
---
--- This function can nest objects and arrays when keys are nested
---
--- @
--- 'traverseJSON' "a.b" {a: {b: 12}} == Just "12"
--- 'traverseJSON' "a.b" {a: {b: false}} == Just "false"
--- 'traverseJSON' "a" {a: {b: false}} == Nothing
--- 'traverseJSON' "1" [false, true] == Just "true"
--- 'traverseJSON' "0.a" [{a: "hi"}] == Just "hi"
--- 'traverseJSON' "0" [] == Nothing
--- @
-traverseJSON :: Key -> Value -> Maybe Value
-traverseJSON key value =
- case (unconsKey key, value) of
-   (Nothing, v) ->
-     Just v
-   (Just ("keys", ""), Object o) ->
-      HashMap.lookup "keys" o
-        <|> pure (
-              String $
-              mconcat $
-              intersperse "," $
-              sort $
-              HashMap.keys o)
-   (Just (c, ks), Object o) ->
-     HashMap.lookup c o >>= traverseJSON ks
-   (Just ("keys", ""), Array vs) ->
-      Just $
-        String $
-        mconcat $
-        intersperse "," $
-        fmap (Text.pack . show)
-        [0..length vs - 1]
-   (Just (c, ks), Array vs) -> do
-     n :: Int <- readMaybe $ Text.unpack c
-     v <- vs !? n
-     traverseJSON ks v
-   (Just _, _) ->
-     Nothing
+-- | Create a 'Source' from a json value, never fails.
+fromValue' :: FilePath -> Value -> Either ProblemWithJSON Source
+fromValue' filepath rawValue = do
+  value <- parseValue rawValue
+  pure $ Source JsonSource {..}
 
--- | Get the list of available keys inside a json value
-listKeysInJSON :: Value -> [Key]
-listKeysInJSON = go ""
+-- | Traverse a 'ValueIR' using a 'Key' to get the deepest 'ValueIR' that
+-- matches that 'Key'
+--
+-- This means it's is possible that the value returned is not the value at
+-- that 'Key'.
+traverseJSON :: Key -> ValueIR -> ValueIR
+traverseJSON = go
   where
-  go :: Key -> Value -> [Key]
+  go :: Key -> ValueIR -> ValueIR
   go key value =
     case (unconsKey key, value) of
-      (_, Object o) ->
-        let
-          self =
-            case valueToText <$> HashMap.lookup "_self" o of
-              Just _ -> [key]
-              Nothing -> []
-        in self ++ do
-          (k, v) <- HashMap.toList o
-          guard $ isValidKeyFragment k
-          go (key /. fromText k) v
-      (_, Array as) -> do
-        (index :: Integer, v) <- zip [0..] $ Vector.toList as
-        go (key /. mkKey (show index)) v
-      (Nothing, _) -> []
-      (_, _) -> [key]
+      (Just (k, restOfKey), ObjectIR _ _ o) -> fromMaybe value $ do
+        x <- HashMap.lookup k o
+        Just $ go restOfKey x
+      (Just (k, restOfKey), ArrayIR _ vs) -> fromMaybe value $ do
+        n <- readMaybe @Int $ Text.unpack k
+        x <- vs !? n
+        Just $ go restOfKey x
+      (Nothing, v) -> v
+      (Just (_, _), v) -> v
 
--- | Turn json 'Value' into 'Text' to return that key
-valueToText :: Value -> Maybe Text
-valueToText (String t) = Just t
-valueToText (Object o) = do
-  selfValue <- HashMap.lookup "_self" o
-  valueToText selfValue
-valueToText (Array _as) = Nothing
-valueToText (Number n) = Just $ Text.decodeUtf8 $ L.toStrict $ encode $ Number n
-valueToText (Bool b) = Just $ boolToString b
-valueToText (Null) = Nothing
-
--- | Turn a 'GHC.Types.Bool' into a 'Text'
-boolToString :: Bool -> Text
-boolToString True = "true"
-boolToString False = "false"
-
--- | Because we use an old version of aeson
-resultToMaybe :: Result a -> Maybe a
-resultToMaybe (Error _) = Nothing
-resultToMaybe (Success a) = Just a
-
-type RawKey = [Text]
-
--- | Validates that a json has the correct format for keys,
--- since Conferer 'Key's are pretty restricted.
---
--- The Source will work with incorrect keys but they will
--- be ignored.
-invalidJsonKeys :: Value -> [RawKey]
-invalidJsonKeys = filter (not . validKey) . allKeys
+-- | Get the list of available keys inside a json value
+listKeysInJSON :: ValueIR -> [Key]
+listKeysInJSON = go True
   where
-    validFragmentForJSON :: Text -> Bool
-    validFragmentForJSON fragment = isValidKeyFragment fragment || fragment == "_self"
-    validKey :: RawKey -> Bool
-    validKey fragments = all validFragmentForJSON fragments
-
--- | Returns all keys in a json object
-allKeys :: Value -> [RawKey]
-allKeys = go mempty
-  where
-    go :: RawKey -> Value -> [RawKey]
-    go rawkey value =
-      case value of
-        Object o ->
-          let
-            keys =
-              fmap (\t -> rawkey ++ [t])
-              . HashMap.keys
-              $ o
-          in keys ++ do
-          (k, v) <- HashMap.toList o
-          let subkey = rawkey ++ [k]
-          go subkey v
-        Array as -> do
-          (index :: Integer, v) <- zip [0..] $ Vector.toList as
-          let subkey = rawkey ++ [Text.pack $ show index]
-          go subkey v
-        _ -> []
+  go :: Bool -> ValueIR -> [Key]
+  go isTopLevel value =
+    case value of
+      ObjectIR k (Just _) o ->
+        (if isTopLevel then [] else [k]) ++
+          concatMap (go False) (HashMap.elems o)
+      ObjectIR _ _ o -> do
+        concatMap (go False) (HashMap.elems o)
+      ArrayIR _ vs -> do
+        concatMap (go False) vs
+      RawValue k _ _ ->
+        if isTopLevel then [] else [k]

--- a/packages/aeson/test/Conferer/Source/AesonSpec.hs
+++ b/packages/aeson/test/Conferer/Source/AesonSpec.hs
@@ -5,11 +5,14 @@ import Test.Hspec
 
 import Conferer.Source
 import Conferer.Source.Aeson
+import Data.Aeson
 
 spec :: Spec
 spec = do
   describe "json source" $ do
-    let mk = return . fromValue "dir/file.json"
+    let
+      mk :: Value -> IO Source
+      mk = fromValue "file.json"
     describe "#getKeyInSource" $ do
       it "getting an existing path returns the right value" $ do
         c <- mk [aesonQQ| {"postgres": {"url": "some url", "ssl": true}} |]
@@ -31,12 +34,6 @@ spec = do
           c <- mk [aesonQQ| { key: {_self: 72}} |]
           res <- getKeyInSource c "key"
           res `shouldBe` Just "72"
-
-      context "with a key that's not valid" $ do
-        it "ignores the value" $ do
-          c <- mk [aesonQQ| { key: {key_: 72}} |]
-          res <- getKeyInSource c "key"
-          res `shouldBe` Nothing
 
       describe "with an array" $ do
         it "getting a path with number gets the right value" $ do
@@ -137,115 +134,100 @@ spec = do
           c <- mk [aesonQQ|[true, true, true]|]
           res <- getSubkeysInSource c ""
           res `shouldBe` ["0", "1", "2"]
-      describe "gettings keys with invalid names" $ do
-        it "ignores those names" $ do
-          c <- mk [aesonQQ|{"_a": 7}|]
-          res <- getSubkeysInSource c ""
-          res `shouldBe` []
-      describe "when json keys don't follow the conferer Key format" $ do
-        it "ignores the evil keys" $ do
-          c <- mk [aesonQQ|{some: {k_e_y: 0}}|]
-          res <- getSubkeysInSource c ""
-          res `shouldBe` []
       describe "when '_self' is present" $ do
         it "gets an object if it has '_self'" $ do
           c <- mk [aesonQQ|{some: {_self: 7, key: 0}}|]
           res <- getSubkeysInSource c ""
           res `shouldBe` ["some", "some.key"]
+      describe "when a list inside an object" $ do
+        it "returns the numbers of the list" $ do
+          c <- mk [aesonQQ|{"a": ["a"]}|]
+          res <- getSubkeysInSource c "a"
+          res `shouldBe` ["a.0"]
     describe "#invalidJsonKeys" $ do
-      context "with some common keys" $
-        it "works" $ do
-          invalidJsonKeys [aesonQQ|{postgres: {url: "some url", ssl: true}} |]
-            `shouldBe` []
-      context "with one top level invalid key" $
-        it "fails" $ do
-          invalidJsonKeys [aesonQQ|{k_e_y: {}} |]
-            `shouldBe` [["k_e_y"]]
+      describe "listing keys in non existant path" $ do
+        it "gets no keys" $ do
+          parseValue [aesonQQ|{_self: {}, a: false}|]
+            `shouldBe` Left (InvalidSelfValue [] [aesonQQ|{}|])
+      describe "gettings keys with invalid names" $ do
+        it "ignores those names" $ do
+          parseValue [aesonQQ|{"_a": 7}|]
+            `shouldBe` Left (InvalidKey [] "_a")
       context "with one invalid key inside an object" $
         it "fails" $ do
-          invalidJsonKeys [aesonQQ|{some: {k_e_y: {}}} |]
-            `shouldBe` [["some", "k_e_y"]]
+          parseValue [aesonQQ|{some: {k_e_y: {}}} |]
+            `shouldBe` Left (InvalidKey ["some"] "k_e_y")
       context "with one invalid key inside an array" $
         it "fails" $ do
-          invalidJsonKeys [aesonQQ|[{k_e_y: {}}]|]
-            `shouldBe` [["0", "k_e_y"]]
-      context "with _self" $
-        it "succeeds" $ do
-          invalidJsonKeys [aesonQQ|[{some: {_self: 7}}]|]
-            `shouldBe` []
+          parseValue [aesonQQ|[{k_e_y: {}}]|]
+            `shouldBe` Left (InvalidKey ["0"] "k_e_y")
       context "with empty key" $
         it "fails" $ do
-          invalidJsonKeys [aesonQQ|{"": 7}|]
-            `shouldBe` [[""]]
+          parseValue [aesonQQ|{"": 7}|]
+            `shouldBe` Left (InvalidKey [] "")
     describe "#explainNotFound" $ do
       context "When there is an on root that's missing a key" $ do
         it "recomends adding that key mentioning 'the root object'" $ do
-          let s = fromValue "file.json" [aesonQQ|{}|]
+          s <- mk [aesonQQ|{}|]
           explainNotFound s "port"
             `shouldBe` "Replacing the whole json from '{}' to '{\"port\":\"some value\"}' on file 'file.json'"
 
       context "When there is an object that's missing a key" $ do
         it "recomends adding that key that's necessary" $ do
-          let s = fromValue "file.json" [aesonQQ|{server: {}}|]
+          s <- mk [aesonQQ|{server: {}}|]
           explainNotFound s "server.port"
             `shouldBe` "Replacing the value at 'server' from '{}' to '{\"port\":\"some value\"}' on file 'file.json'"
 
       context "When there is an object in the key" $ do
         it "recomends replacing it with a value" $ do
-          let s = fromValue "file.json" [aesonQQ|{port: {}}|]
+          s <- mk [aesonQQ|{port: {}}|]
           explainNotFound s "port"
             `shouldBe` "Replacing the value at 'port' from '{}' to '\"some value\"' on file 'file.json'"
 
       context "When there is a primitive somewhere in the middle" $ do
         it "recommends using '_self' and adding the key" $ do
-          let s = fromValue "file.json" [aesonQQ|{server: 7}|]
+          s <- mk [aesonQQ|{server: 7}|]
           explainNotFound s "server.port"
             `shouldBe` "Replacing the value at 'server' from '7' to '{\"_self\":7,\"port\":\"some value\"}' on file 'file.json'"
 
       context "When the key ends with `keys`" $ do
         it "recommends adding an object beside adding the raw key" $ do
-          let s = fromValue "file.json" [aesonQQ|{}|]
+          s <- mk [aesonQQ|{}|]
           explainNotFound s "servers.keys"
             `shouldBe` "Replacing the whole json from '{}' to '{\"servers\":{\"keys\":\"some value\"}}' on file 'file.json'"
 
       context "When the key has an array" $ do
         it "recommends turning the array into an object and using self" $ do
-          let s = fromValue "file.json" [aesonQQ|{"port": []}|]
+          s <- mk [aesonQQ|{"port": []}|]
           explainNotFound s "port"
             `shouldBe` "Replacing the value at 'port' from '[]' to '\"some value\"' on file 'file.json'"
 
       context "When the key has an array with values" $ do
         it "recommends turning the array into an object and using self (adding existing keys)" $ do
-          let s = fromValue "file.json" [aesonQQ|{"port": [false]}|]
+          s <- mk [aesonQQ|{"port": [false]}|]
           explainNotFound s "port"
             `shouldBe` "Replacing the value at 'port' from '[false]' to '{\"0\":false,\"_self\":\"some value\"}' on file 'file.json'"
 
-      context "When the _self key has an object" $ do
-        it "recommends replacing it with some value" $ do
-          let s = fromValue "file.json" [aesonQQ|{"port": {"_self": {}}}|]
-          explainNotFound s "port"
-            `shouldBe` "Replacing the value at 'port._self' from '{}' to '\"some value\"' on file 'file.json'"
-
-      context "When the _self key has an array" $ do
-        it "recommends replacing it with some value" $ do
-          let s = fromValue "file.json" [aesonQQ|{"port": {"_self": []}}|]
-          explainNotFound s "port"
-            `shouldBe` "Replacing the value at 'port._self' from '[]' to '\"some value\"' on file 'file.json'"
     describe "#explainSettedKey" $ do
       context "with a simple value" $ do
         it "returns its path" $ do
-          let s = fromValue "file.json" [aesonQQ|{"port": 9999}|]
+          s <- mk [aesonQQ|{"port": 9999}|]
           explainSettedKey s "port"
             `shouldBe` "json key 'port' on file 'file.json'"
+      context "with a simple value" $ do
+        it "returns its path" $ do
+          s <- mk [aesonQQ|{"port": 9999}|]
+          explainSettedKey s "keys"
+            `shouldBe` "json key 'keys' on file 'file.json'"
       context "with a simple value inside an array" $ do
         xit "returns its path" $ do
-          let s = fromValue "file.json" [aesonQQ|{"port": [9999]}|]
+          s <- mk [aesonQQ|{"port": [9999]}|]
           explainSettedKey s "port.0"
             `shouldBe` "json key 'port[0]' on file 'file.json'"
           -- Here and in every test I'd like to user the more normal
           -- notation for paths (the one from js)
       context "with an object with _self" $ do
         it "returns its real path (including _self)" $ do
-          let s = fromValue "file.json" [aesonQQ|{"port": {"_self": 9999}}|]
+          s <- mk [aesonQQ|{"port": {"_self": 9999}}|]
           explainSettedKey s "port"
             `shouldBe` "json key 'port._self' on file 'file.json'"

--- a/packages/conferer/CHANGELOG.md
+++ b/packages/conferer/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [PVP](https://pvp.haskell.org/).
 
 * Added new functions `getKeyFromSources` and `getKeyFromDefaults`
 * Change structure of `KeyLookupResult` to keep invariants of `getKeyFromSources` `getKeyFromDefaults`
+* Added `asTopLevel` to display pretty errors and use `exitFailure` upon errors
+* Fake `Show` and `Eq` instances for `Config`
+* Reasonable implementations for the new `explain*` function on `Source` for the default sources
+* `TestSource` which is like `InMemorySource` but throws when asking to explain keys (should be only
+  used for testing)
 
 ### Removed
 
@@ -19,6 +24,17 @@ and this project adheres to [PVP](https://pvp.haskell.org/).
 
 * `listSubkeys` now ignores the defaults (since without a type parameter we can't guarantee that a value
     will always be found)
+* `FoundInSources` now contains the index of the source it was found on
+* `FromConfig` instances:
+  - `File` throw with a `File` type on root key instead of string on every subkey (to improve error messages)
+  - `List` now throws more specific errors (like `String` on `keys` instead of `[a]` on `.`) to
+    report more actionable errors
+  - `Bool` now accepts more values as true: `t`, `y`, `yes`, `1` and as false: `f`, `n`, `no`, `0`
+* Moved exceptions related code from `FromConfig/Internal.hs` to `FromConfig/Internal/Types.hs`
+* `explainSettedKey` and `explainMissingKey` to the `Source` typeclass to give better explanations
+  of missing keys and setted keys
+* `NullSource` and `InMemorySource` now accept one or more functions to implement the explain
+  function from `Source`
 
 ## [v1.1.0.0] - 2021-03-01
 

--- a/packages/conferer/conferer.cabal
+++ b/packages/conferer/conferer.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ff270bcc4d8154db08adc97727d49c5f1f9a4b1399dfac9ef714617d097a2500
+-- hash: 7047fb1b6c4ba214affd2ca1a654f1914a857ed6a36e5b2136b40e04c5b9b693
 
 name:           conferer
 version:        1.1.0.0
@@ -33,6 +33,7 @@ library
       Conferer.Config.Internal.Types
       Conferer.FromConfig
       Conferer.FromConfig.Internal
+      Conferer.FromConfig.Internal.Types
       Conferer.Key
       Conferer.Key.Internal
       Conferer.Source
@@ -44,6 +45,7 @@ library
       Conferer.Source.Namespaced
       Conferer.Source.Null
       Conferer.Source.PropertiesFile
+      Conferer.Source.Test
       Conferer.Test
   other-modules:
       Paths_conferer

--- a/packages/conferer/src/Conferer.hs
+++ b/packages/conferer/src/Conferer.hs
@@ -63,8 +63,8 @@ fetch' :: forall a. (FromConfig a, Typeable a) => Config -> a -> IO a
 fetch' c a = do
   asTopLevel $ fetchFromRootConfigWithDefault c a
 
--- | Given an IO action that run it but if it throws a Conferer related excpetion
--- pretty print it and exit the program with failure.
+-- | Given an IO action, it runs and if it throws a Conferer related exception
+-- it pretty prints the error and exits the program with failure.
 asTopLevel :: IO a -> IO a
 asTopLevel action =
   action

--- a/packages/conferer/src/Conferer.hs
+++ b/packages/conferer/src/Conferer.hs
@@ -61,7 +61,13 @@ fetch c = fetch' c configDef
 --   the default from 'configDef'
 fetch' :: forall a. (FromConfig a, Typeable a) => Config -> a -> IO a
 fetch' c a = do
-  fetchFromRootConfigWithDefault c a
+  asTopLevel $ fetchFromRootConfigWithDefault c a
+
+-- | Given an IO action that run it but if it throws a Conferer related excpetion
+-- pretty print it and exit the program with failure.
+asTopLevel :: IO a -> IO a
+asTopLevel action =
+  action
      `catch` (\(e :: MissingRequiredKey) -> do
        putStrLn $ displayException e
        exitFailure)

--- a/packages/conferer/src/Conferer.hs
+++ b/packages/conferer/src/Conferer.hs
@@ -43,6 +43,9 @@ import qualified Conferer.Source.Env as Env
 import qualified Conferer.Source.CLIArgs as Cli
 import qualified Conferer.Source.PropertiesFile as PropertiesFile
 import Conferer.Config (Defaults)
+import Conferer.FromConfig.Internal.Types
+import Control.Exception
+import System.Exit (exitFailure)
 
 -- | Use the 'FromConfig' instance to get a value of type @a@ from the config
 --   using some default fallback. The most common use for this is creating a custom
@@ -52,12 +55,19 @@ import Conferer.Config (Defaults)
 --   but malformed somehow (@"abc"@ as an Int) but that depends on the 'FromConfig'
 --   implementation for the type.
 fetch :: forall a. (FromConfig a, Typeable a, DefaultConfig a) => Config -> IO a
-fetch c = fetchFromRootConfigWithDefault c configDef
+fetch c = fetch' c configDef
 
 -- | Same as 'fetch' but it accepts the default as a parameter instead of using
 --   the default from 'configDef'
 fetch' :: forall a. (FromConfig a, Typeable a) => Config -> a -> IO a
-fetch' = fetchFromRootConfigWithDefault
+fetch' c a = do
+  fetchFromRootConfigWithDefault c a
+     `catch` (\(e :: MissingRequiredKey) -> do
+       putStrLn $ displayException e
+       exitFailure)
+     `catch` (\(e :: ConfigParsingError) -> do
+       putStrLn $ displayException e
+       exitFailure)
 
 -- | Same as 'fetch'' but you can specify a 'Key' instead of the root key which allows
 --   you to fetch smaller values when you need them instead of a big one at

--- a/packages/conferer/src/Conferer/Config.hs
+++ b/packages/conferer/src/Conferer/Config.hs
@@ -37,4 +37,5 @@ import Conferer.Key
 import Data.Function
 import Data.Dynamic (Dynamic)
 
+-- | Type of the defaults of a 'Config'
 type Defaults = [(Key, Dynamic)]

--- a/packages/conferer/src/Conferer/Config/Internal.hs
+++ b/packages/conferer/src/Conferer/Config/Internal.hs
@@ -60,7 +60,7 @@ getKeyFromSources key config = do
   let possibleKeys = getKeysFromMappings (configKeyMappings config) key
   untilJust (fmap (\MappedKey{..} -> getRawKeyInSources mappedKey config) possibleKeys)
     >>= \case
-      Just (k, i, t) -> pure $ FoundInSources t i k
+      Just (key, index, text) -> pure $ FoundInSources text index key
       Nothing -> pure $ MissingKey () $ fmap mappedKey possibleKeys
 
 -- | Alias for a mapping from one key to another used for transforming keys

--- a/packages/conferer/src/Conferer/Config/Internal.hs
+++ b/packages/conferer/src/Conferer/Config/Internal.hs
@@ -55,13 +55,15 @@ getKey key config = do
 --
 -- This is utility function that has proved to be useful but when doubt
 -- use 'getKey'
-getKeyFromSources :: Key -> Config -> IO (KeyLookupResult ('OnlySources))
+getKeyFromSources :: Key -> Config -> IO (KeyLookupResult 'OnlySources)
 getKeyFromSources key config = do
   let possibleKeys = getKeysFromMappings (configKeyMappings config) key
   untilJust (fmap (\MappedKey{..} -> getRawKeyInSources mappedKey config) possibleKeys)
     >>= \case
-      Just (key, index, text) -> pure $ FoundInSources text index key
-      Nothing -> pure $ MissingKey () $ fmap mappedKey possibleKeys
+      Just (actualKey, index, text) ->
+        pure $ FoundInSources text index actualKey
+      Nothing ->
+        pure $ MissingKey () $ fmap mappedKey possibleKeys
 
 -- | Alias for a mapping from one key to another used for transforming keys
 type KeyMapping = (Key, Key)

--- a/packages/conferer/src/Conferer/Config/Internal/Types.hs
+++ b/packages/conferer/src/Conferer/Config/Internal/Types.hs
@@ -29,7 +29,13 @@ data Config =
   { configSources :: [Source]
   , configDefaults :: Map Key [Dynamic]
   , configKeyMappings :: [(Key, Key)]
-  } deriving (Show)
+  }
+
+instance Show Config where
+  show _ = "Config"
+
+instance Eq Config where
+  _ == _ = True
 
 -- | Result of a key lookup in a 'Config'
 --
@@ -46,7 +52,7 @@ data Config =
 --       of the result is always 'Text'
 data KeyLookupResult lookupTarget
   = MissingKey () [Key]
-  | FoundInSources (SourcesResultType lookupTarget) Key
+  | FoundInSources (SourcesResultType lookupTarget) Int Key
   | FoundInDefaults (DefaultsResultType lookupTarget) Key
 
 -- | Target of a lookup that the 'KeyLookupResult' is parameterized on

--- a/packages/conferer/src/Conferer/FromConfig.hs
+++ b/packages/conferer/src/Conferer/FromConfig.hs
@@ -22,6 +22,7 @@ module Conferer.FromConfig
   , MissingRequiredKey
   , throwMissingRequiredKey
   , missingRequiredKey
+  , missingRequiredKeys
 
   , ConfigParsingError
   , throwConfigParsingError
@@ -40,6 +41,7 @@ module Conferer.FromConfig
   ) where
 
 import Conferer.FromConfig.Internal
+import Conferer.FromConfig.Internal.Types
 import Conferer.Config.Internal.Types
 import Conferer.Config.Internal
 import Conferer.Key

--- a/packages/conferer/src/Conferer/FromConfig/Internal.hs
+++ b/packages/conferer/src/Conferer/FromConfig/Internal.hs
@@ -118,7 +118,7 @@ instance {-# OVERLAPPABLE #-} (Typeable a, FromConfig a) =>
           MissingKey () keys ->
             throwMissingRequiredKeys @String (fmap (/. "keys") keys) config
 #if __GLASGOW_HASKELL__ < 808
-          (FoundInSources v _ _) ->
+          FoundInSources v _ _ ->
             absurd v
 #endif
       Just subkeys -> do

--- a/packages/conferer/src/Conferer/FromConfig/Internal.hs
+++ b/packages/conferer/src/Conferer/FromConfig/Internal.hs
@@ -73,6 +73,9 @@ class FromConfig a where
           _ -> config
     to <$> fromConfigG key configWithDefaults
 
+-- | Main function to get keys from a config, it wraps 'fromConfig' with some general
+
+-- functionallity, like fetch overriding.
 fetchFromConfig :: forall a. (FromConfig a, Typeable a) => Key -> Config -> IO a
 fetchFromConfig key config =
   case getKeyFromDefaults @(OverrideFromConfig a) key config of
@@ -199,6 +202,7 @@ newtype File =
   File FilePath
   deriving (Show, Eq, Ord, Read)
 
+-- | Unpack the 'FilePath' from a 'File'
 unFile :: File -> FilePath
 unFile (File f) = f
 
@@ -250,6 +254,8 @@ parseBool text =
     "1" -> pure False
     _ -> Nothing
 
+-- | Special type that's used internally to implement fromConfig
+-- overriding.
 data OverrideFromConfig a =
   OverrideFromConfig (Key -> Config -> IO a)
 

--- a/packages/conferer/src/Conferer/FromConfig/Internal.hs
+++ b/packages/conferer/src/Conferer/FromConfig/Internal.hs
@@ -31,6 +31,7 @@ import Data.Function ((&))
 
 import Conferer.Key
 import Conferer.Config.Internal.Types
+import Conferer.FromConfig.Internal.Types
 import Conferer.Config.Internal
 import qualified Data.Char as Char
 import Control.Monad (forM)
@@ -93,9 +94,9 @@ instance {-# OVERLAPPABLE #-} Typeable a => FromConfig a where
       FoundInDefaults a _key ->
         pure a
       MissingKey () keys ->
-        throwMissingRequiredKeys @a keys
+        throwMissingRequiredKeys @a keys config
 #if __GLASGOW_HASKELL__ < 808
-      FoundInSources v _ -> absurd v
+      FoundInSources v _ _ -> absurd v
 #endif
 
 
@@ -112,12 +113,12 @@ instance {-# OVERLAPPABLE #-} (Typeable a, FromConfig a) =>
     case keysForItems of
       Nothing -> do
         case getKeyFromDefaults @[a] key config of
-          (FoundInDefaults a _keys) ->
+          FoundInDefaults a _keys ->
             pure a
           MissingKey () keys ->
-            throwMissingRequiredKeys @[a] keys
+            throwMissingRequiredKeys @String (fmap (/. "keys") keys) config
 #if __GLASGOW_HASKELL__ < 808
-          (FoundInSources v _) ->
+          (FoundInSources v _ _) ->
             absurd v
 #endif
       Just subkeys -> do
@@ -227,13 +228,7 @@ instance FromConfig File where
         $ fromMaybe (unFile $ fromMaybe "" defaultPath) filepath
     if FilePath.isValid constructedFilePath
       then return $ File constructedFilePath
-      else throwMissingRequiredKeys @String
-        [ key
-        , key /. "extension"
-        , key /. "dirname"
-        , key /. "basename"
-        , key /. "filename"
-        ]
+      else throwMissingRequiredKey @File key config
     where
       applyIfPresent f maybeComponent =
         (\fp -> maybe fp (f fp) maybeComponent)
@@ -242,8 +237,17 @@ instance FromConfig File where
 parseBool :: Text -> Maybe Bool
 parseBool text =
   case Text.toLower text of
-    "false" -> Just False
-    "true" -> Just True
+    "false" -> pure False
+    "f" -> pure False
+    "no" -> pure False
+    "n" -> pure False
+    "0" -> pure False
+
+    "true" -> pure True
+    "t" -> pure True
+    "yes" -> pure True
+    "y" -> pure True
+    "1" -> pure False
     _ -> Nothing
 
 data OverrideFromConfig a =
@@ -267,18 +271,18 @@ fetchFromConfigWith :: forall a. Typeable a => (Text -> Maybe a) -> Key -> Confi
 fetchFromConfigWith parseValue key config = do
   getKey @a key config >>=
     \case
-      FoundInSources value k ->
+      MissingKey () k -> do
+        throwMissingRequiredKeys @a k config
+
+      FoundInSources value index k ->
         case parseValue value of
           Just a -> do
             return a
           Nothing -> do
-            throwConfigParsingError @a k value
+            throwConfigParsingError @a k value index config
 
-      FoundInDefaults v _key ->
-        return v
-
-      MissingKey () k -> do
-        throwMissingRequiredKeys @a k
+      FoundInDefaults a _k ->
+        return a
 
 -- | Helper function does the plumbing of desconstructing a default into smaller
 -- defaults, which is usefull for nested 'fetchFromConfig'.
@@ -309,73 +313,6 @@ addDefaultsAfterDeconstructingToDefaults destructureValue key config = do
 overrideFetch :: forall a. Typeable a => (Key -> Config -> IO a) -> Dynamic
 overrideFetch f =
   toDyn @(OverrideFromConfig a) $ OverrideFromConfig f
-
--- | Exception to show that a value couldn't be parsed properly
-data ConfigParsingError =
-  ConfigParsingError Key Text TypeRep
-  deriving (Typeable, Eq)
-
-instance Exception ConfigParsingError
-instance Show ConfigParsingError where
-  show (ConfigParsingError key value aTypeRep) =
-    concat
-    [ "Couldn't parse value '"
-    , Text.unpack value
-    , "' from key '"
-    , show key
-    , "' as "
-    , show aTypeRep
-    ]
-
--- | Helper function to throw 'ConfigParsingError'
-throwConfigParsingError :: forall a b. (Typeable a) => Key -> Text -> IO b
-throwConfigParsingError key text =
-  throwIO $ configParsingError @a  key text
-
--- | Helper function to create a 'ConfigParsingError'
-configParsingError :: forall a. (Typeable a) => Key -> Text -> ConfigParsingError
-configParsingError key text =
-  ConfigParsingError key text $ typeRep (Proxy :: Proxy a)
-
--- | Exception to show that some non optional 'Key' was missing while trying
--- to 'fetchFromConfig'
-data MissingRequiredKey =
-  MissingRequiredKey [Key] TypeRep
-  deriving (Typeable, Eq)
-
-instance Exception MissingRequiredKey
-instance Show MissingRequiredKey where
-  show (MissingRequiredKey keys aTypeRep) =
-    concat
-    [ "Failed to get a '"
-    , show aTypeRep
-    , "' from keys: "
-    , Text.unpack
-      $ Text.intercalate ", "
-      $ fmap (Text.pack . show)
-      $ keys
-
-    ]
-
--- | Simplified helper function to throw a 'MissingRequiredKey'
-throwMissingRequiredKey :: forall t a. Typeable t => Key -> IO a
-throwMissingRequiredKey key =
-  throwMissingRequiredKeys @t [key]
-
--- | Simplified helper function to create a 'MissingRequiredKey'
-missingRequiredKey :: forall t. Typeable t => Key -> MissingRequiredKey
-missingRequiredKey key =
-  missingRequiredKeys @t [key]
-
--- | Helper function to throw a 'MissingRequiredKey'
-throwMissingRequiredKeys :: forall t a. Typeable t => [Key] -> IO a
-throwMissingRequiredKeys keys =
-  throwIO $ missingRequiredKeys @t keys
-
--- | Helper function to create a 'MissingRequiredKey'
-missingRequiredKeys :: forall a. (Typeable a) => [Key] -> MissingRequiredKey
-missingRequiredKeys keys =
-  MissingRequiredKey keys (typeRep (Proxy :: Proxy a))
 
 -- | Same as 'fetchFromConfig' using the root key
 fetchFromRootConfig :: forall a. (FromConfig a, Typeable a) => Config -> IO a

--- a/packages/conferer/src/Conferer/FromConfig/Internal/Types.hs
+++ b/packages/conferer/src/Conferer/FromConfig/Internal/Types.hs
@@ -48,14 +48,17 @@ data MissingRequiredKey =
 instance Exception MissingRequiredKey where
   displayException (MissingRequiredKey someKeys aTypeRep config) =
     let
-      sourcesExplanations =
-        fmap (\s -> explainNotFound s $ head someKeys) $
-        configSources config
+      explainSingleKey k =
+        concat
+        $ fmap (\source -> "* " ++ explainNotFound source k ++ "\n")
+        $ configSources config
+      keyExplanations =
+        fmap explainSingleKey someKeys
     in unlines
     [ "Couldn't find a '" ++ show aTypeRep ++ "'."
     , ""
     , "You can set it by either:"
-    ] ++ (intercalate "\n" $ fmap ("* " ++) $ sourcesExplanations)
+    ] ++ intercalate "\n" keyExplanations
 
 -- | Simplified helper function to throw a 'MissingRequiredKey'
 throwMissingRequiredKey :: forall t a. Typeable t => Key -> Config -> IO a

--- a/packages/conferer/src/Conferer/FromConfig/Internal/Types.hs
+++ b/packages/conferer/src/Conferer/FromConfig/Internal/Types.hs
@@ -1,3 +1,11 @@
+-- |
+-- Copyright: (c) 2021 Lucas David Traverso
+-- License: MPL-2.0
+-- Maintainer: Lucas David Traverso <lucas6246@gmail.com>
+-- Stability: unstable
+-- Portability: portable
+--
+-- FromConfig related internal types
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
@@ -11,13 +19,13 @@ import Conferer.Config.Internal.Types
 import Conferer.Source.Internal
 import Data.List (intercalate)
 
-type FailureExplanation = Text
-type OriginalValue = Text
-
 -- | Exception to show that a value couldn't be parsed properly
 data ConfigParsingError =
   ConfigParsingError Key OriginalValue TypeRep Int Config
   deriving (Typeable, Show, Eq)
+
+-- | Type of the value returned by the 'Source'
+type OriginalValue = Text
 
 instance Exception ConfigParsingError where
   displayException (ConfigParsingError key _value aTypeRep sourceIndex c) =
@@ -40,7 +48,7 @@ configParsingError key value sourceIndex config =
   ConfigParsingError key value (typeRep (Proxy :: Proxy a)) sourceIndex config
 
 -- | Exception to show that some non optional 'Key' was missing while trying
--- to 'fetchFromConfig'
+-- to 'Conferer.FromConfig.Internal.fetchFromConfig'
 data MissingRequiredKey =
   MissingRequiredKey [Key] TypeRep Config
   deriving (Typeable, Show, Eq)

--- a/packages/conferer/src/Conferer/FromConfig/Internal/Types.hs
+++ b/packages/conferer/src/Conferer/FromConfig/Internal/Types.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+module Conferer.FromConfig.Internal.Types where
+
+import Control.Exception
+import Conferer.Key (Key)
+import Data.Text (Text)
+import Data.Typeable
+import Conferer.Config.Internal.Types
+import Conferer.Source.Internal
+import Data.List (intercalate)
+
+type FailureExplanation = Text
+type OriginalValue = Text
+
+-- | Exception to show that a value couldn't be parsed properly
+data ConfigParsingError =
+  ConfigParsingError Key OriginalValue TypeRep Int Config
+  deriving (Typeable, Show, Eq)
+
+instance Exception ConfigParsingError where
+  displayException (ConfigParsingError key _value aTypeRep sourceIndex c) =
+    concat
+    [ "Failed to interpret "
+    , explainSettedKey (configSources c !! sourceIndex) key
+    , " as '"
+    , show aTypeRep
+    , "'"
+    ]
+
+-- | Helper function to throw 'ConfigParsingError'
+throwConfigParsingError :: forall a b. (Typeable a) => Key -> Text -> Int -> Config -> IO b
+throwConfigParsingError key value sourceIndex config =
+  throwIO $ configParsingError @a  key value sourceIndex config
+
+-- | Helper function to create a 'ConfigParsingError'
+configParsingError :: forall a. (Typeable a) => Key -> Text -> Int -> Config -> ConfigParsingError
+configParsingError key value sourceIndex config =
+  ConfigParsingError key value (typeRep (Proxy :: Proxy a)) sourceIndex config
+
+-- | Exception to show that some non optional 'Key' was missing while trying
+-- to 'fetchFromConfig'
+data MissingRequiredKey =
+  MissingRequiredKey [Key] TypeRep Config
+  deriving (Typeable, Show, Eq)
+
+instance Exception MissingRequiredKey where
+  displayException (MissingRequiredKey someKeys aTypeRep config) =
+    let
+      sourcesExplanations =
+        fmap (\s -> explainNotFound s $ head someKeys) $
+        configSources config
+    in unlines
+    [ "Couldn't find a '" ++ show aTypeRep ++ "'."
+    , ""
+    , "You can set it by either:"
+    ] ++ (intercalate "\n" $ fmap ("* " ++) $ sourcesExplanations)
+
+-- | Simplified helper function to throw a 'MissingRequiredKey'
+throwMissingRequiredKey :: forall t a. Typeable t => Key -> Config -> IO a
+throwMissingRequiredKey key config =
+  throwMissingRequiredKeys @t [key] config
+
+-- | Simplified helper function to create a 'MissingRequiredKey'
+missingRequiredKey :: forall t. Typeable t => Key -> Config -> MissingRequiredKey
+missingRequiredKey key config =
+  missingRequiredKeys @t [key] config
+
+-- | Helper function to throw a 'MissingRequiredKey'
+throwMissingRequiredKeys :: forall t a. Typeable t => [Key] -> Config -> IO a
+throwMissingRequiredKeys keys config =
+  throwIO $ missingRequiredKeys @t keys config
+
+-- | Helper function to create a 'MissingRequiredKey'
+missingRequiredKeys :: forall a. (Typeable a) => [Key] -> Config -> MissingRequiredKey
+missingRequiredKeys keys config =
+  MissingRequiredKey keys (typeRep (Proxy :: Proxy a)) config
+

--- a/packages/conferer/src/Conferer/Source/InMemory.hs
+++ b/packages/conferer/src/Conferer/Source/InMemory.hs
@@ -15,30 +15,64 @@ import Data.Text (Text)
 
 import Conferer.Source
 
+newtype ExplainNotFound = ExplainNotFound (Key -> String)
+newtype ExplainSettedKey = ExplainSettedKey (Key -> String)
+
 -- | A 'Source' mostly use for mocking which is configured directly using a
--- 'Map'
-newtype InMemorySource =
+-- 'Map', is also contains some functions for explaining the user how to set
+-- this source's keys, you can check other sources for examples
+data InMemorySource =
   InMemorySource
-  { configMap :: Map Key Text
-  } deriving (Show, Eq)
+  { innerRawMap :: RawInMemorySource
+  , inMemoryExplainNotFound :: Key -> String
+  , inMemoryExplainSettedKey :: Key -> String
+  }
+
+instance Show InMemorySource where
+  show InMemorySource {..} = "InMemorySource " ++ show innerRawMap
 
 instance IsSource InMemorySource where
   getKeyInSource InMemorySource {..} key =
-    return $ Map.lookup key configMap
+    return $ lookupKey key innerRawMap
   getSubkeysInSource InMemorySource {..} key = do
-    return $ filter (\k -> key `isKeyPrefixOf` k && key /= k) $ Map.keys configMap
+    return $ subKeys key innerRawMap
+  explainNotFound InMemorySource {..} key =
+    inMemoryExplainNotFound key
+  explainSettedKey InMemorySource {..} key =
+    inMemoryExplainSettedKey key
+
+newtype RawInMemorySource =
+  RawInMemorySource (Map Key Text)
+  deriving (Show, Eq)
+
+lookupKey :: Key -> RawInMemorySource -> Maybe Text
+lookupKey key (RawInMemorySource m) =
+  Map.lookup key m
+
+subKeys :: Key -> RawInMemorySource -> [Key]
+subKeys key (RawInMemorySource m) =
+  filter (\k -> key `isKeyPrefixOf` k && key /= k) $ Map.keys m
+
+rawFromMap :: Map Key Text -> RawInMemorySource
+rawFromMap =
+  RawInMemorySource
+
+rawFromAssociations :: [(Key, Text)] -> RawInMemorySource
+rawFromAssociations =
+  RawInMemorySource . Map.fromList
 
 -- | Create a 'SourceCreator' from a list of associations
-fromConfig :: [(Key, Text)] -> SourceCreator
-fromConfig configMap _config =
-  return $ fromAssociations configMap
+fromConfig :: ExplainNotFound -> ExplainSettedKey -> [(Key, Text)] -> SourceCreator
+fromConfig notFound setted configMap _config =
+  return $ fromAssociations notFound setted configMap
 
 -- | Create a 'Source' from a 'Map'
-fromMap :: Map Key Text -> Source
-fromMap configMap =
-  Source . InMemorySource $ configMap
+fromMap :: ExplainNotFound -> ExplainSettedKey -> Map Key Text -> Source
+fromMap (ExplainNotFound inMemoryExplainNotFound) (ExplainSettedKey inMemoryExplainSettedKey) configMap =
+  let innerRawMap = rawFromMap configMap
+  in Source $ InMemorySource {..}
 
 -- | Create a 'Source' from a list of associations
-fromAssociations :: [(Key, Text)] -> Source
-fromAssociations =
-  fromMap . Map.fromList
+fromAssociations :: ExplainNotFound -> ExplainSettedKey -> [(Key, Text)] -> Source
+fromAssociations notFound setted assocs =
+  fromMap notFound setted $ Map.fromList assocs

--- a/packages/conferer/src/Conferer/Source/Internal.hs
+++ b/packages/conferer/src/Conferer/Source/Internal.hs
@@ -27,9 +27,23 @@ class IsSource s where
   -- | This function is used by the 'Conferer.Config.Config' to list possible values
   -- from the 'Source' that if the user 'getKeyInSource', it will be found.
   getSubkeysInSource :: s -> Key -> IO [Key]
+  -- | This function is used to explain the user how to set this 'Key' using this
+  -- 'Source'.
+  --
+  -- It is used as: "You can set the key by " '++' exaplainNotFound source key
+  explainNotFound :: s -> Key -> String
+  -- | This function is used to reference a 'Key' without exposing 'Key's to the user.
+  --
+  -- It is used as: "I tried to read " '++' explainSettedKey source key ++ " as an
+  -- Int but if failed"
+  explainSettedKey :: s -> Key -> String
 
 instance IsSource Source where
   getKeyInSource (Source source) =
     getKeyInSource source
   getSubkeysInSource (Source source) =
     getSubkeysInSource source
+  explainNotFound (Source source) =
+    explainNotFound source
+  explainSettedKey (Source source) =
+    explainSettedKey source

--- a/packages/conferer/src/Conferer/Source/Namespaced.hs
+++ b/packages/conferer/src/Conferer/Source/Namespaced.hs
@@ -30,6 +30,14 @@ instance IsSource NamespacedSource where
       Just innerKey -> do
         fmap (scopeKey /.) <$> getSubkeysInSource innerSource innerKey
       Nothing -> return []
+  explainNotFound NamespacedSource {..} key =
+    case stripKeyPrefix scopeKey key of
+      Just innerKey -> explainNotFound innerSource innerKey
+      Nothing -> "Doing nothing, you can't use this source for that key"
+  explainSettedKey NamespacedSource {..} key =
+    case stripKeyPrefix scopeKey key of
+      Just innerKey -> explainSettedKey innerSource innerKey
+      Nothing -> "Doing nothing, you can't use this source for that key"
 
 -- | Create a 'SourceCreator' from a prefix and another 'SourceCreator'
 fromConfig :: Key -> SourceCreator -> SourceCreator

--- a/packages/conferer/src/Conferer/Source/Null.hs
+++ b/packages/conferer/src/Conferer/Source/Null.hs
@@ -11,22 +11,19 @@ module Conferer.Source.Null where
 import Conferer.Source
 
 -- | Stub source that has no keys
-data NullSource =
-  NullSource
-  deriving (Show, Eq)
+data NullSource = NullSource
+  { nullExplainNotFound :: Key -> String
+  }
+
+instance Show NullSource where
+  show _ = "NullSource"
 
 instance IsSource NullSource where
   getKeyInSource _source _key =
     return Nothing
   getSubkeysInSource _source _key =
     return []
-
--- | Create 'SourceCreator'
-fromConfig :: SourceCreator
-fromConfig _config =
-  return empty
-
--- | Create a 'Source'
-empty :: Source
-empty =
-  Source $ NullSource
+  explainNotFound NullSource {..} = nullExplainNotFound
+  explainSettedKey _source key =
+    "Called explainSettedKey on NullSource with key " ++ show key ++ " , \
+    \which is probably a bug in conferer (please report at https://github.com/ludat/conferer/issues)"

--- a/packages/conferer/src/Conferer/Source/PropertiesFile.hs
+++ b/packages/conferer/src/Conferer/Source/PropertiesFile.hs
@@ -92,6 +92,9 @@ fromFileContent originalFilePath fileContent =
       rawMap = InMemory.rawFromAssociations keyValues
   in Source $ PropertiesFileSource {..}
 
+-- | Create a 'Source' given a file that doesn't exist, this 'Source'
+-- will fail searching keys but it'll complain about that missing
+-- file
 fromNonExistentFilepath :: FilePath -> Source
 fromNonExistentFilepath filePath =
   Source $ Null.NullSource

--- a/packages/conferer/src/Conferer/Source/PropertiesFile.hs
+++ b/packages/conferer/src/Conferer/Source/PropertiesFile.hs
@@ -10,7 +10,7 @@ module Conferer.Source.PropertiesFile where
 
 import Data.Text (Text)
 import Data.Function ((&))
-import System.Directory (doesFileExist)
+import System.Directory
 import Data.Maybe (catMaybes)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -19,20 +19,41 @@ import Conferer.Source
 import Conferer.Source.Files
 import qualified Conferer.Source.Null as Null
 import qualified Conferer.Source.InMemory as InMemory
+import Data.List
 
 -- | 'Source' that uses a config file in @config/{env}.properties@ and
 -- parses it as a properties file with @some.key=a value@ lines
-data PropertiesFileSource =
-  PropertiesFileSource
-  { originalFilePath :: FilePath
-  , innerSource :: Source
-  } deriving (Show)
+data PropertiesFileSource
+  = PropertiesFileSource
+    { originalFilePath :: FilePath
+    , rawMap :: InMemory.RawInMemorySource
+    }
+  deriving (Show)
 
 instance IsSource PropertiesFileSource where
   getKeyInSource PropertiesFileSource{..} key = do
-    getKeyInSource innerSource key
+    return $ InMemory.lookupKey key rawMap
+
   getSubkeysInSource PropertiesFileSource{..} key = do
-    getSubkeysInSource innerSource key
+    return $ InMemory.subKeys key rawMap
+
+  explainNotFound PropertiesFileSource{..} key =
+    concat
+    [ "Adding a new line '"
+    , concat $ intersperse "." $ fmap Text.unpack $ rawKeyComponents key
+    , "=some value' to the file '"
+    , originalFilePath
+    , "'"
+    ]
+  explainSettedKey PropertiesFileSource{..} key =
+    concat
+    [ "key '"
+    , concat $ intersperse "." $ fmap Text.unpack $ rawKeyComponents key
+    , "' (on file '"
+    , originalFilePath
+    , "')"
+    ]
+
 
 -- | Create a 'SourceCreator' using 'getFilePathFromEnv' to get the path to file
 -- and 'fromFilePath'
@@ -50,14 +71,15 @@ fromFilePath filepath _config =
 -- | Create a 'Source' reading the file and using that as a properties file, but
 -- if the file doesn't exist do nothing.
 fromFilePath' :: FilePath -> IO Source
-fromFilePath' filePath = do
+fromFilePath' relativeFilePath = do
+  filePath <- makeAbsolute relativeFilePath
   fileExists <- doesFileExist filePath
   if fileExists
     then do
       fileContent <- Text.readFile filePath
       return $ fromFileContent filePath fileContent
     else
-      return Null.empty
+      return $ fromNonExistentFilepath filePath
 
 -- | Create a 'Source' using some content as a properties file
 fromFileContent :: FilePath -> Text -> Source
@@ -67,8 +89,21 @@ fromFileContent originalFilePath fileContent =
         & Text.lines
         & fmap lineToKeyValue
         & catMaybes
-      innerSource = InMemory.fromAssociations keyValues
+      rawMap = InMemory.rawFromAssociations keyValues
   in Source $ PropertiesFileSource {..}
+
+fromNonExistentFilepath :: FilePath -> Source
+fromNonExistentFilepath filePath =
+  Source $ Null.NullSource
+    { nullExplainNotFound = \key ->
+      concat
+      [ "Creating a file '"
+      , filePath
+      , "' (it doesn't exist now) and adding a line '"
+      , concat $ intersperse "." $ fmap Text.unpack $ rawKeyComponents key
+      , "=some value'."
+      ]
+    }
 
 -- | Transform a line into a key/value pair (or not)
 lineToKeyValue :: Text -> Maybe (Key, Text)

--- a/packages/conferer/src/Conferer/Source/Test.hs
+++ b/packages/conferer/src/Conferer/Source/Test.hs
@@ -30,9 +30,9 @@ instance IsSource TestSource where
   getSubkeysInSource TestSource {..} key = do
     return $ InMemory.subKeys key rawMap
   explainNotFound _ _ =
-    error "Tryig to explain a Test Source, use an InMemory source instead"
+    error "Trying to explain a Test Source, use an InMemory source instead"
   explainSettedKey _ _ =
-    error "Tryig to explain a Test Source, use an InMemory source instead"
+    error "Trying to explain a Test Source, use an InMemory source instead"
 
 -- | Create a 'SourceCreator' from a list of associations
 fromConfig :: [(Key, Text)] -> SourceCreator

--- a/packages/conferer/src/Conferer/Source/Test.hs
+++ b/packages/conferer/src/Conferer/Source/Test.hs
@@ -14,10 +14,10 @@ import Data.Map (Map)
 import Data.Text (Text)
 
 -- | 'Source' for testing, mainly for checking that given some
--- behavior from 'Source' some 'fetchFromConfig' will behave
--- properly.
+-- behavior from 'Source' some 'Conferer.FromConfig.Internal.fetchFromConfig'
+-- will behave properly.
 --
--- Note: Don't use this source for real code, use 'InMemorySource'
+-- Note: Don't use this source for real code, use 'Conferer.Source.InMemory.InMemorySource'
 -- instead, since this source can't explain things to the user
 data TestSource =
   TestSource

--- a/packages/conferer/src/Conferer/Source/Test.hs
+++ b/packages/conferer/src/Conferer/Source/Test.hs
@@ -1,0 +1,50 @@
+-- |
+-- Copyright: (c) 2021 Lucas David Traverso
+-- License: MPL-2.0
+-- Maintainer: Lucas David Traverso <lucas6246@gmail.com>
+-- Stability: stable
+-- Portability: portable
+--
+-- Source for testing
+module Conferer.Source.Test where
+
+import Conferer.Source
+import qualified Conferer.Source.InMemory as InMemory
+import Data.Map (Map)
+import Data.Text (Text)
+
+-- | 'Source' for testing, mainly for checking that given some
+-- behavior from 'Source' some 'fetchFromConfig' will behave
+-- properly.
+--
+-- Note: Don't use this source for real code, use 'InMemorySource'
+-- instead, since this source can't explain things to the user
+data TestSource =
+  TestSource
+  { rawMap :: InMemory.RawInMemorySource
+  } deriving (Show, Eq)
+
+instance IsSource TestSource where
+  getKeyInSource TestSource {..} key =
+    return $ InMemory.lookupKey key rawMap
+  getSubkeysInSource TestSource {..} key = do
+    return $ InMemory.subKeys key rawMap
+  explainNotFound _ _ =
+    error "Tryig to explain a Test Source, use an InMemory source instead"
+  explainSettedKey _ _ =
+    error "Tryig to explain a Test Source, use an InMemory source instead"
+
+-- | Create a 'SourceCreator' from a list of associations
+fromConfig :: [(Key, Text)] -> SourceCreator
+fromConfig configMap _config =
+  return $ fromAssociations configMap
+
+-- | Create a 'Source' from a 'Map'
+fromMap :: Map Key Text -> Source
+fromMap =
+  Source . TestSource . InMemory.rawFromMap
+
+-- | Create a 'Source' from a list of associations
+fromAssociations :: [(Key, Text)] -> Source
+fromAssociations =
+  Source . TestSource . InMemory.rawFromAssociations

--- a/packages/conferer/src/Conferer/Test.hs
+++ b/packages/conferer/src/Conferer/Test.hs
@@ -11,14 +11,14 @@ module Conferer.Test
   ) where
 
 import Conferer.Config
-import qualified Conferer.Source.InMemory as InMemory
 import Data.Text (Text)
 import Data.Dynamic
+import qualified Conferer.Source.Test as Test
 
 -- | Create a Config mostly used for testing 'Conferer.FromConfig.FromConfig'
 --   instances without having to create a full config
 configWith :: [(Key, Dynamic)] -> [(Key, Text)] -> IO Config
 configWith defaults keyValues =
-  emptyConfig 
+  emptyConfig
   & addDefaults defaults
-  & addSource (InMemory.fromConfig keyValues)
+  & addSource (Test.fromConfig keyValues)

--- a/packages/conferer/test/Conferer/ConfigSpec.hs
+++ b/packages/conferer/test/Conferer/ConfigSpec.hs
@@ -5,7 +5,7 @@ import Test.Hspec
 import Data.Dynamic
 
 import Conferer.Config
-import Conferer.Source.InMemory
+import Conferer.Source.Test
 
 spec :: Spec
 spec = do
@@ -36,12 +36,12 @@ spec = do
         it "getting an key returns unwraps the original map" $ do
           c <- mkConfig' [] [] [("some.key", "1")]
           res <- getKeyFromSources "some.key" c
-          res `shouldBe` FoundInSources "1" "some.key"
+          res `shouldBe` FoundInSources "1" 1 "some.key"
 
         it "getting an existent key returns in the bottom maps gets it" $ do
           c <- mkConfig' [] [("some.key", "2")] [("some.key", "1")]
           res <- getKeyFromSources "some.key" c
-          res `shouldBe` FoundInSources "2" "some.key"
+          res `shouldBe` FoundInSources "2" 0 "some.key"
       describe "with some key mapping" $ do
         context "with basic one to one mapping" $
           it "gets the value through a mapping" $ do
@@ -50,7 +50,7 @@ spec = do
                   []
                   [ ("server", "aaa") ]
             res <- getKeyFromSources "something" c
-            res `shouldBe` FoundInSources "aaa" "server"
+            res `shouldBe` FoundInSources "aaa" 0 "server"
         context "with a nested key mapping" $ do
           it "goes through all the mappings and gets the right value" $ do
             c <- mkConfig
@@ -61,7 +61,7 @@ spec = do
                   [ ("server", "aaa")
                   ]
             res <- getKeyFromSources "something" c
-            res `shouldBe` FoundInSources "aaa" "server"
+            res `shouldBe` FoundInSources "aaa" 0 "server"
         context "with circular mappings" $ do
           it "gets the first key" $ do
             c <- mkConfig
@@ -73,7 +73,7 @@ spec = do
                   [ ("c", "aaa")
                   ]
             res <- getKeyFromSources "a" c
-            res `shouldBe` FoundInSources "aaa" "c"
+            res `shouldBe` FoundInSources "aaa" 0 "c"
         context "with nested key" $ do
           it "maps the right upper key" $ do
             c <- mkConfig
@@ -83,7 +83,7 @@ spec = do
                   [ ("b.k", "aaa")
                   ]
             res <- getKeyFromSources "a.k" c
-            res `shouldBe` FoundInSources "aaa" "b.k"
+            res `shouldBe` FoundInSources "aaa" 0 "b.k"
         context "with some defaults" $ do
           it "maps and allows getting the default" $ do
             c <- mkConfig
@@ -117,15 +117,15 @@ spec = do
           res <- listSubkeys "other" c
           res `shouldBe` []
       context "with a config with defaults" $ do
-        xit "returns those defaults in the list" $ do
+        it "returns those defaults in the list" $ do
           c <- mkConfig [] [] [("some.key", "7")]
           res <- listSubkeys "some" c
           res `shouldBe` ["some.key"]
       context "with configs in both defaults and sources" $ do
-        xit "returns both results combined" $ do
+        it "returns only the sources" $ do
           c <- mkConfig [] [("some.key", toDyn @Int 7)] [("some.other", "")]
           res <- listSubkeys "some" c
-          res `shouldBe` ["some.key", "some.other"]
+          res `shouldBe` ["some.other"]
       context "mappings" $ do
         context "with a simple mapping and a configured value" $ do
           it "returns the keys that are present based on the mapping" $ do

--- a/packages/conferer/test/Conferer/FromConfig/Extended.hs
+++ b/packages/conferer/test/Conferer/FromConfig/Extended.hs
@@ -28,12 +28,12 @@ import Data.Function
 
 import Conferer.Config
 import Conferer.FromConfig
-import qualified Conferer.Source.InMemory as InMemory
+import qualified Conferer.Source.Test as Test
 
 configWith :: [(Key, Text)] -> IO Config
 configWith keyValues =
   emptyConfig
-  & addSource (InMemory.fromConfig keyValues)
+  & addSource (Test.fromConfig keyValues)
 
 ensureEmptyConfigThrows :: forall a. (HasCallStack, Typeable a, FromConfig a, Show a) => SpecWith ()
 ensureEmptyConfigThrows =

--- a/packages/conferer/test/Conferer/FromConfig/Extended.hs
+++ b/packages/conferer/test/Conferer/FromConfig/Extended.hs
@@ -7,15 +7,11 @@ module Conferer.FromConfig.Extended
   ( module Conferer.FromConfig
   , module GHC.Generics
   , configWith
-  , anyConfigParserError
-  , aConfigParserError
-  , aMissingRequiredKey
-  , aMissingRequiredKeys
   , ensureEmptyConfigThrows
   , ensureUsingDefaultReturnsSameValue
   , ensureSingleConfigParsesTheRightThing
   , ensureSingleConfigThrowsParserError
-  , ensureSingleConfigThrows
+  , ensureSingleFetchThrows
   , ensureFetchParses
   , ensureFetchThrows
   , toDyn
@@ -31,10 +27,6 @@ import Data.Dynamic
 import Data.Function
 
 import Conferer.Config
-import Conferer.FromConfig.Internal
-  ( MissingRequiredKey(..)
-  , ConfigParsingError(..)
-  )
 import Conferer.FromConfig
 import qualified Conferer.Source.InMemory as InMemory
 
@@ -43,43 +35,35 @@ configWith keyValues =
   emptyConfig
   & addSource (InMemory.fromConfig keyValues)
 
-anyConfigParserError :: ConfigParsingError -> Bool
-anyConfigParserError _ = True
-
-aConfigParserError :: Key -> Text -> ConfigParsingError -> Bool
-aConfigParserError key txt (ConfigParsingError k t _) =
-  key == k && t == txt
-
-aMissingRequiredKey :: forall t. Typeable t => Key -> MissingRequiredKey -> Bool
-aMissingRequiredKey key (MissingRequiredKey k t) =
-  [key] == k && typeRep (Proxy :: Proxy t) == t
-
-aMissingRequiredKeys :: forall t. Typeable t => [Key] -> MissingRequiredKey -> Bool
-aMissingRequiredKeys keys (MissingRequiredKey k t) =
-  keys == k && typeRep (Proxy :: Proxy t) == t
-
-data InvalidThing = InvalidThing deriving (Show, Eq)
-
-ensureEmptyConfigThrows :: forall a. (Typeable a, FromConfig a) => SpecWith ()
+ensureEmptyConfigThrows :: forall a. (HasCallStack, Typeable a, FromConfig a, Show a) => SpecWith ()
 ensureEmptyConfigThrows =
   context "with empty config"  $ do
     it "throws an exception" $ do
       config <- configWith []
       fetchFromConfig @a "some.key" config
-        `shouldThrow` aMissingRequiredKey @a "some.key"
+        `shouldThrowExactly` (missingRequiredKey @a "some.key" emptyConfig)
 
 ensureSingleConfigThrowsParserError ::
-    forall a. (FromConfig a, Typeable a) =>
+    forall a. (HasCallStack, FromConfig a, Typeable a, Show a) =>
     Text -> SpecWith ()
 ensureSingleConfigThrowsParserError keyContent =
   context "with invalid types in the defaults"  $ do
     it "throws an exception" $ do
       config <- configWith [("some.key", keyContent)]
       fetchFromConfig @a "some.key" config
-        `shouldThrow` aConfigParserError "some.key" keyContent
+        `shouldThrowExactly` (configParsingError @a "some.key" keyContent 0 emptyConfig)
+
+shouldThrowExactly :: forall e a. (HasCallStack, Exception e, Eq e, Show a) => IO a -> e -> Expectation
+shouldThrowExactly action expectedException = do
+  result <- try @e action
+  case result of
+    Right a -> do
+      fail $ "Expected an exception but got: " ++ show a
+    Left e -> do
+      e `shouldBe` expectedException
 
 ensureUsingDefaultReturnsSameValue ::
-    forall a. (Typeable a, Eq a, Show a, FromConfig a) =>
+    forall a. (HasCallStack, Typeable a, Eq a, Show a, FromConfig a) =>
     a -> SpecWith ()
 ensureUsingDefaultReturnsSameValue value =
   context ("with a default of '" ++ show value ++ "'") $ do
@@ -90,7 +74,7 @@ ensureUsingDefaultReturnsSameValue value =
       fetchedValue `shouldBe` value
 
 ensureSingleConfigParsesTheRightThing ::
-    forall a. (Eq a, Show a, FromConfig a, Typeable a) =>
+    forall a. (HasCallStack, Eq a, Show a, FromConfig a, Typeable a) =>
     Text -> a -> SpecWith ()
 ensureSingleConfigParsesTheRightThing keyContent value =
   context ("with a config value of '" ++ unpack keyContent ++ "'" ) $ do
@@ -99,18 +83,19 @@ ensureSingleConfigParsesTheRightThing keyContent value =
       fetchedValue <- fetchFromConfig @a "some.key" config
       fetchedValue `shouldBe` value
 
-ensureSingleConfigThrows ::
-    forall a e. (FromConfig a, Typeable a, Exception e) =>
-    Text -> (e -> Bool) -> SpecWith ()
-ensureSingleConfigThrows keyContent checkException =
+ensureSingleFetchThrows ::
+    forall a e. (HasCallStack, FromConfig a, Typeable a, Exception e, Eq e, Show a) =>
+    Text -> e -> SpecWith ()
+ensureSingleFetchThrows keyContent checkException =
   it "gets the right value" $ do
     config <- configWith [("some.key", keyContent)]
     fetchFromConfig @a "some.key" config
-      `shouldThrow` checkException
+      `shouldThrowExactly` checkException
 
 ensureFetchParses ::
     forall a.
-    ( FromConfig a
+    ( HasCallStack
+    , FromConfig a
     , Typeable a
     , Eq a
     , Show a
@@ -133,16 +118,19 @@ ensureFetchThrows ::
     ( FromConfig a
     , Typeable a
     , Exception e
+    , Eq e
+    , HasCallStack
+    , Show a
     )
     => [(Key, Text)]
     -> [(Key, Dynamic)]
-    -> (e -> Bool)
+    -> e
     -> SpecWith ()
-ensureFetchThrows configs defaults exceptionCheck =
+ensureFetchThrows configs defaults expectedException =
   it "throws an exception" $ do
     config <- addDefaults (mapKeys defaults) <$> configWith (mapKeys configs)
     fetchFromConfig @a "some.key" config
-      `shouldThrow` exceptionCheck
+      `shouldThrowExactly` expectedException
   where
     mapKeys :: forall x. [(Key, x)] -> [(Key, x)]
     mapKeys = fmap (\(k, x) -> ("some.key" /. k, x))

--- a/packages/conferer/test/Conferer/FromConfig/FileSpec.hs
+++ b/packages/conferer/test/Conferer/FromConfig/FileSpec.hs
@@ -3,8 +3,8 @@ module Conferer.FromConfig.FileSpec (spec) where
 
 import Test.Hspec
 import Conferer.FromConfig.Extended
-import Conferer.FromConfig ()
 import System.FilePath ((</>))
+
 import Data.Text (pack)
 
 spec :: Spec
@@ -14,13 +14,9 @@ spec = do
       ensureFetchParses @File [] [("", toDyn $ File "file.png")] $
         File "file.png"
       ensureFetchThrows @File [] [] $
-        aMissingRequiredKeys @String
+        missingRequiredKeys @File
           [ "some.key"
-          , "some.key.extension"
-          , "some.key.dirname"
-          , "some.key.basename"
-          , "some.key.filename"
-          ]
+          ] emptyConfig
 
       context "with whole path in root" $ do
         ensureFetchParses @File

--- a/packages/conferer/test/Conferer/FromConfig/ListSpec.hs
+++ b/packages/conferer/test/Conferer/FromConfig/ListSpec.hs
@@ -19,7 +19,9 @@ instance FromConfig Thing
 spec :: Spec
 spec = do
   describe "list parsing" $ do
-    ensureEmptyConfigThrows @[Int]
+    ensureFetchThrows @[Int] [] [] $
+      missingRequiredKey @String "some.key.keys" emptyConfig
+
     ensureUsingDefaultReturnsSameValue @[Int] [7]
 
     context "with an empty keys it always gets an empty list" $ do
@@ -146,7 +148,7 @@ spec = do
             , Thing {thingA = 1, thingB = "b"}
             ])
         ]
-        $ aMissingRequiredKey @Int "some.key.defaults.5.a"
+        $ missingRequiredKey @Int "some.key.defaults.5.a" emptyConfig
     context "listing a default keys that's not present ignores the \
             \prototype" $ do
       ensureFetchThrows
@@ -159,7 +161,7 @@ spec = do
             , Thing {thingA = 1, thingB = "b"}
             ])
         ]
-        $ aMissingRequiredKey @Int "some.key.defaults.5.a"
+        $ missingRequiredKey @Int "some.key.defaults.5.a" emptyConfig
     context "fetching maps every key (and they can be used if the lower \
             \fromconfig uses listSubkeys" $ do
       ensureFetchParses

--- a/packages/conferer/test/Conferer/FromConfig/MaybeSpec.hs
+++ b/packages/conferer/test/Conferer/FromConfig/MaybeSpec.hs
@@ -17,7 +17,7 @@ spec = do
     context "when the key is missing" $ do
       ensureFetchParses @(Maybe Int) [] [] Nothing
     context "when the key is there but has a wrong value" $ do
-      ensureFetchThrows @(Maybe Int) [("", "Bleh")] [] anyConfigParserError
+      ensureFetchThrows @(Maybe Int) [("", "Bleh")] [] $ configParsingError @Int "some.key" "Bleh" 0 emptyConfig
     context "with default of the inner type" $ do
       ensureFetchParses @(Maybe Int) [] [("", toDyn @Int 7)] $ Just 7
     context "with default of a Just inner type" $ do

--- a/packages/conferer/test/Conferer/Source/InMemorySpec.hs
+++ b/packages/conferer/test/Conferer/Source/InMemorySpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeApplications #-}
 module Conferer.Source.InMemorySpec where
 
 import Test.Hspec
@@ -9,24 +10,38 @@ spec :: Spec
 spec = do
   describe "in memory source" $ do
     let source =
-          fromAssociations [("postgres.url", "some url")]
+          fromAssociations
+            (ExplainNotFound $ reverse . show)
+            (ExplainSettedKey show)
+            [("postgres.url", "some url")]
+    describe "#getKeyInSource" $ do
+      it "getting a non existent key returns an empty config" $ do
+        res <- getKeyInSource source "some.key"
+        res `shouldBe` Nothing
 
-    it "getting a non existent key returns an empty config" $ do
-      res <- getKeyInSource source "some.key"
-      res `shouldBe` Nothing
+      it "getting an existent key returns unwraps the original map" $ do
+        res <- getKeyInSource source "postgres.url"
+        res `shouldBe` Just "some url"
 
-    it "getting an existent key returns unwraps the original map" $ do
-      res <- getKeyInSource source "postgres.url"
-      res `shouldBe` Just "some url"
+    describe "#getSubkeysInSource" $ do
+      it "listing subkeys works" $ do
+        res <- getSubkeysInSource source "postgres"
+        res `shouldBe` ["postgres.url"]
 
-    it "listing subkeys works" $ do
-      res <- getSubkeysInSource source "postgres"
-      res `shouldBe` ["postgres.url"]
+      it "listing subkeys never returns the same key" $ do
+        res <- getSubkeysInSource source "postgres.url"
+        res `shouldBe` []
 
-    it "listing subkeys never returns the same key" $ do
-      res <- getSubkeysInSource source "postgres.url"
-      res `shouldBe` []
+      it "listing subkeys that are not present" $ do
+        res <- getSubkeysInSource source "stuff"
+        res `shouldBe` []
 
-    it "listing subkeys that are not present" $ do
-      res <- getSubkeysInSource source "stuff"
-      res `shouldBe` []
+    describe "#explainSettedKey" $ do
+      it "uses the function that was passed" $ do
+        explainSettedKey source "postgres.url"
+          `shouldBe` show @Key "postgres.url"
+
+    describe "#explainNotFound" $ do
+      it "uses the function that was passed" $ do
+        explainNotFound source "dracula"
+          `shouldBe` show @Key "alucard"

--- a/packages/conferer/test/Conferer/Source/NamespacedSpec.hs
+++ b/packages/conferer/test/Conferer/Source/NamespacedSpec.hs
@@ -4,7 +4,7 @@ import Test.Hspec
 
 import Conferer.Source
 
-import qualified Conferer.Source.InMemory as InMemory
+import qualified Conferer.Source.Test as Test
 import Conferer.Source.Namespaced
 
 spec :: Spec
@@ -12,7 +12,7 @@ spec = do
   describe "namespaced config" $ do
     let source =
           fromInner "postgres" $
-            InMemory.fromAssociations [("url", "some url")]
+            Test.fromAssociations [("url", "some url")]
     it "return nothing if the key doesn't match" $ do
       res <- getKeyInSource source "url"
       res `shouldBe` Nothing

--- a/packages/conferer/test/Conferer/Source/NullSpec.hs
+++ b/packages/conferer/test/Conferer/Source/NullSpec.hs
@@ -8,5 +8,5 @@ import           Conferer.Source.Null
 spec :: Spec
 spec = do
   it "always fails to get a key" $ do
-    res <- getKeyInSource empty "some.key"
+    res <- getKeyInSource (NullSource (const "")) "some.key"
     res `shouldBe` Nothing

--- a/packages/conferer/test/Conferer/Source/PropertiesFileSpec.hs
+++ b/packages/conferer/test/Conferer/Source/PropertiesFileSpec.hs
@@ -9,24 +9,35 @@ spec :: Spec
 spec = do
   describe "with a properties file config" $ do
     let mk = return . fromFileContent "file.properties"
-    it "getting an existent key returns unwraps top level value (without \
-       \children)" $ do
-      c <- mk "some.key=a value"
-      res <- getKeyInSource c "some.key"
-      res `shouldBe` Just "a value"
+    describe "#getKeyInSource" $ do
+      it "getting an existent key returns unwraps top level value (without \
+         \children)" $ do
+        c <- mk "some.key=a value"
+        res <- getKeyInSource c "some.key"
+        res `shouldBe` Just "a value"
 
-    it "getting an existent key for a child gets that value" $ do
-      c <- mk "some.key=b"
-      res <- getKeyInSource c "some.key"
-      res `shouldBe` Just "b"
+      it "getting an existent key for a child gets that value" $ do
+        c <- mk "some.key=b"
+        res <- getKeyInSource c "some.key"
+        res `shouldBe` Just "b"
 
-    it "keys should always be consistent as to how the words are separated" $ do
-      c <- mk "some.key=a value"
-      res <- getKeyInSource c "some.key"
-      res `shouldBe` Just "a value"
+      it "keys should always be consistent as to how the words are separated" $ do
+        c <- mk "some.key=a value"
+        res <- getKeyInSource c "some.key"
+        res `shouldBe` Just "a value"
 
-    it "respects leading spaces in values" $ do
-      c <- mk "some.key= a value "
-      res <- getKeyInSource c "some.key"
-      res `shouldBe` Just " a value "
+      it "respects leading spaces in values" $ do
+        c <- mk "some.key= a value "
+        res <- getKeyInSource c "some.key"
+        res `shouldBe` Just " a value "
+    describe "#explainNotFound" $ do
+      it "recommends adding the right line to the file" $ do
+        s <- mk ""
+        explainNotFound s "some.key"
+          `shouldBe` "Adding a new line 'some.key=some value' to the file 'file.properties'"
+    describe "#explainSettedKey" $ do
+      it "recommends adding the right line to the file" $ do
+        s <- mk "some.key=thing"
+        explainSettedKey s "some.key"
+          `shouldBe` "key 'some.key' (on file 'file.properties')"
 

--- a/packages/conferer/test/ConfererSpec.hs
+++ b/packages/conferer/test/ConfererSpec.hs
@@ -8,7 +8,7 @@ import Test.Hspec
 
 import Data.Text (Text)
 import Conferer.FromConfig (fetchFromConfig)
-import Conferer.Source.InMemory (fromConfig)
+import Conferer.Source.Test (fromConfig)
 import Data.Dynamic (toDyn)
 import Conferer.Config (Config)
 import Conferer (mkConfig', Key)

--- a/packages/dhall/CHANGELOG.md
+++ b/packages/dhall/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [PVP](https://pvp.haskell.org/).
 
 ## [Unreleased]
 
-Nothing
+### Added
+
+* More strict parser:
+  - Disallow invalid keys with a clear error message
+  - Disallow using objects or arrays in the `_self` special key
+* Implement the explain interfaces for `DhallSource`
 
 ## [v1.1.0.0] 2021-03-01
 

--- a/packages/dhall/src/Conferer/Source/Dhall.hs
+++ b/packages/dhall/src/Conferer/Source/Dhall.hs
@@ -47,10 +47,20 @@ fromFilePath' relativeFilePath = do
       dhallExpr <- inputExpr fileContent
       case dhallToJSON dhallExpr of
         Right jsonConfig -> do
-          return $ JSON.fromValue filePath jsonConfig
+          JSON.fromValue filePath jsonConfig
         Left compileError ->
           throwIO $ ErrorCall (show compileError)
     else do
       return $ Source $ Null.NullSource
-        { nullExplainNotFound = undefined
+        { nullExplainNotFound = \key ->
+          concat
+            [ "Creating a file '"
+            , filePath
+            , "' (it doesn't exist now) "
+            , "and set the path '"
+            -- TODO: this should show an example of dhall but creating and showing dhall
+            -- seems pretty hard so I'll do it later
+            , JSON.showRawKey $ rawKeyComponents key
+            , "'"
+            ]
         }

--- a/packages/hedis/CHANGELOG.md
+++ b/packages/hedis/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [PVP](https://pvp.haskell.org/).
 
 ## [Unreleased]
 
-Nothing
+### Changed
+
+* Improved errors when parsing the url
 
 ## [v1.1.0.0] 2021-03-07
 

--- a/packages/hedis/src/Conferer/FromConfig/Hedis.hs
+++ b/packages/hedis/src/Conferer/FromConfig/Hedis.hs
@@ -62,9 +62,9 @@ instance FromConfig Redis.ConnectInfo where
 -- act as if it wasn't present
 #if MIN_VERSION_hedis(0,10,0)
     config <-
-      fetchFromConfig @(Maybe Text) (key /. "url") firstConfig
+      getKeyFromSources (key /. "url") firstConfig
         >>= \case
-        Just connectionString -> do
+        FoundInSources connectionString i k -> do
           case Redis.parseConnectInfo $ unpack connectionString of
             Right Redis.ConnInfo{..} -> do
               return $
@@ -76,8 +76,8 @@ instance FromConfig Redis.ConnectInfo where
                     , (key /. "database", toDyn connectDatabase)
                     ]
             Left _e ->
-              throwConfigParsingError @Redis.ConnectInfo key connectionString
-        Nothing -> do
+              throwConfigParsingError @Redis.ConnectInfo k connectionString i originalConfig
+        _ -> do
           return firstConfig
 #else
     config <- return firstConfig

--- a/packages/yaml/CHANGELOG.md
+++ b/packages/yaml/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [PVP](https://pvp.haskell.org/).
 
 ## [Unreleased]
 
-Nothing
+### Added
+
+* More strict parser:
+  - Disallow invalid keys with a clear error message
+  - Disallow using objects or arrays in the `_self` special key
+* Implement the explain interfaces for `YamlSource`
 
 ## [v1.1.0.0] 2021-03-01
 

--- a/packages/yaml/conferer-yaml.cabal
+++ b/packages/yaml/conferer-yaml.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 74c5b092926dae6975cbd2a510874b1160e2686cb938d560803691c967fa3094
+-- hash: 91a59b94b272100a2091d299af7f6e568f71956e14610b4297345ac4033a1c01
 
 name:           conferer-yaml
 version:        1.1.0.0
@@ -38,6 +38,7 @@ library
       base >=4.3 && <5
     , conferer >=1.1.0.0 && <2.0.0.0
     , conferer-aeson >=1.0.0.0 && <2.0.0.0
+    , directory >=1.2.2.0 && <2
     , yaml >=0.8 && <1.0
   if impl(ghc >= 8.4.1)
     ghc-options: -Wpartial-fields
@@ -57,6 +58,7 @@ test-suite specs
     , conferer >=1.1.0.0 && <2.0.0.0
     , conferer-aeson >=1.0.0.0 && <2.0.0.0
     , conferer-yaml
+    , directory >=1.2.2.0 && <2
     , hspec
     , yaml >=0.8 && <1.0
   if impl(ghc >= 8.4.1)

--- a/packages/yaml/package.yaml
+++ b/packages/yaml/package.yaml
@@ -14,6 +14,7 @@ dependencies:
   - conferer >= 1.1.0.0 && < 2.0.0.0
   - conferer-aeson >= 1.0.0.0 && < 2.0.0.0
   - yaml >= 0.8 && < 1.0
+  - directory >= 1.2.2.0 && < 2
 
 tests:
   specs:

--- a/packages/yaml/src/Conferer/Source/Yaml.hs
+++ b/packages/yaml/src/Conferer/Source/Yaml.hs
@@ -9,6 +9,7 @@
 module Conferer.Source.Yaml where
 
 import Data.Yaml
+import System.Directory
 
 import qualified Conferer.Source.Aeson as JSON
 import Conferer.Source.Files
@@ -26,10 +27,11 @@ fromFilePath :: FilePath -> SourceCreator
 fromFilePath filePath _config =
   fromFilePath' filePath
 
--- | Create a 'Source' by reading the provided path as json 
+-- | Create a 'Source' by reading the provided path as json
 fromFilePath' :: FilePath -> IO Source
-fromFilePath' filePath = do
+fromFilePath' relativeFilePath = do
+  filePath <- makeAbsolute relativeFilePath
   configAsJson <- decodeFileEither filePath
   case configAsJson of
-    Right jsonConfig -> return $ JSON.fromValue jsonConfig
+    Right jsonConfig -> return $ JSON.fromValue filePath jsonConfig
     Left parseException -> error (show parseException)


### PR DESCRIPTION
# Description

Avoid using keys related vocabulary when talking to the user, since more often than not translating from key into a source specific thing is not trivial

So instead of the error:

```
$ example-exec --server.port=aa
Couldn't parse value 'aa' from key '"server.port"' as Int

$ AWESOMEAPP_SERVER_PORT=aa example-exec
Couldn't parse value 'aa' from key '"server.port"' as Int
```

we now get:

```
$ example-exec --server.port=aa
Failed to interpret cli param '--server.port' as 'Int'

$ AWESOMEAPP_SERVER_PORT=aa example-exec
Failed to interpret env var 'AWESOMEAPP_SERVER_PORT' as 'Int'
```

Also for missing keys, it goes from:

```
$ example-exec
Failed to get a 'Int' from keys: "some.key"
```

to

```
$ example-exec
Couldn't find a 'Int'.

You can set it by either:
* Passing the cli arg: --some.key="the value"
* Setting the environment variable: AWESOMEAPP_SOME_KEY
* Adding a new line 'some.key=some value' to the file '/home/ludat/Projects/conferer/example/config/development.properties'
```

# Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added changes to the relevant changelog
- [x] I have made corresponding changes to the documentation
- [x] I have added haddock comments for every new function and data
