### PR TITLE
Use the new version of haskell/actions/setup

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -31,34 +31,26 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-haskell@v1.1.3
-      name: Setup Haskell Stack
-      id: setuphaskell
-      with:
-        enable-stack: true
-        stack-no-global: true
-        stack-version: latest
-
-    - uses: actions/cache@v1
-      name: Cache stack files on windows
-      if: ${{ matrix.os == 'windows' }}
-      with:
-        path: 'C:\sr'
-        key: ${{ runner.os }}-${{ matrix.snapshot }}-stack2
-
-    - uses: actions/cache@v1
-      name: Cache stack files on linux
-      if: ${{ matrix.os == 'ubuntu' }}
-      with:
-        path: "~/.stack"
-        key: ${{ runner.os }}-${{ matrix.snapshot }}-stack2
-
     - name: Setup stack.yaml
       shell: bash
       run: |
         mv -vf "stack-ci.yaml" ./stack.yaml || true
         mv -vf "stack-${{ matrix.snapshot }}.yaml" ./stack.yaml || true
         mv -vf "stack-${{ matrix.snapshot }}-${{ matrix.os }}.yaml" ./stack.yaml || true
+
+    - uses: haskell/actions/setup@v1.2.1
+      name: Setup Haskell Stack
+      id: setuphaskell
+      with:
+        enable-stack: true
+        stack-no-global: true
+        stack-setup-ghc: true
+
+    - uses: actions/cache@v1
+      name: Cache stack files on windows
+      with:
+        path: ${{ steps.setuphaskell.outputs.stack-root }}
+        key: ${{ runner.os }}-${{ matrix.snapshot }}-stack2
 
     - name: Build and test
       shell: bash
@@ -69,7 +61,7 @@ jobs:
           exit 0
         fi
         stack setup --resolver=${{ matrix.snapshot }}
-        echo stack_root: $STACK_ROOT
+        echo "stack_root: ${{ steps.setuphaskell.outputs.stack-root }}"
         stack --version
         stack --resolver=${{ matrix.snapshot }} ghc -- --version
         attempts=0

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -65,13 +65,10 @@ jobs:
         echo "stack_root: ${{ steps.setuphaskell.outputs.stack-root }}"
         stack --version
         stack --resolver=${{ matrix.snapshot }} ghc -- --version
-        attempts=0
-        stack clean --resolver=${{ matrix.snapshot }}
-        while ! stack build -j 1 --resolver=${{ matrix.snapshot }} --ghc-options=-Werror --test --bench; do
-          if [ "$attempts" -gt 5 ]; then
-            echo "too many attempts ($attempts)"
-            exit 1
-          fi
-          echo Deps install failed, retrying
-          attempts=$(( $attempts + 1))
-        done
+
+        # we first build everything without running the tests (with unlimited parallelism)
+        stack build --resolver=${{ matrix.snapshot }} --ghc-options=-Werror --test --bench --no-run-tests
+
+        # once that's done we run the tests in a single threaded fashion to avoid
+        # https://github.com/commercialhaskell/stack/issues/5024#issuecomment-845001389
+        stack build --resolver=${{ matrix.snapshot }} --ghc-options=-Werror --test --bench -j 1

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,7 +17,10 @@ jobs:
       matrix:
         os:
           - ubuntu
-          - macOS
+          # There is some linking problems when using the cache so builds are very slow
+          # so we avoid them on the regular CI (since linux and macos are pretty similar
+          # already)
+          # - macOS
           - windows
         snapshot:
           - 'lts-10.10'

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -31,30 +31,31 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup stack.yaml
-      shell: bash
-      run: |
-        mv -vf "stack-ci.yaml" ./stack.yaml || true
-        mv -vf "stack-${{ matrix.snapshot }}.yaml" ./stack.yaml || true
-        mv -vf "stack-${{ matrix.snapshot }}-${{ matrix.os }}.yaml" ./stack.yaml || true
-
     - uses: haskell/actions/setup@v1.2.1
       name: Setup Haskell Stack
       id: setuphaskell
       with:
         enable-stack: true
         stack-no-global: true
-        stack-setup-ghc: true
 
     - uses: actions/cache@v1
-      name: Cache stack files on windows
+      name: Cache stack files
       with:
         path: ${{ steps.setuphaskell.outputs.stack-root }}
         key: ${{ runner.os }}-${{ matrix.snapshot }}-stack2
 
+    - name: Setup stack.yaml
+      shell: bash
+      run: |
+        set -x
+        mv -vf "stack-ci.yaml" ./stack.yaml || true
+        mv -vf "stack-${{ matrix.snapshot }}.yaml" ./stack.yaml || true
+        mv -vf "stack-${{ matrix.snapshot }}-${{ matrix.os }}.yaml" ./stack.yaml || true
+
     - name: Build and test
       shell: bash
       run: |
+        set -x
         grep . stack.yaml
         if grep SKIP stack.yaml; then
           echo Skipped because that snapshot is broken

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os:
           - ubuntu
-          # - macOS
+          - macOS
           - windows
         snapshot:
           - 'lts-10.10'

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -30,24 +30,27 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-haskell@v1.1.3
+    - uses: haskell/actions/setup@v1.2.1
       name: Setup Haskell Stack
       id: setuphaskell
       with:
         enable-stack: true
         stack-no-global: true
-        stack-version: latest
 
-    - uses: actions/cache@v1
-      name: Cache stack files on macOS
-      if: ${{ matrix.os == 'macOS' }}
-      with:
-        path: "~/.stack"
-        key: ${{ runner.os }}-${{ matrix.snapshot }}-stack2
+    # There is some kind of linking problem when actually sharing cache files
+    # between builds so we disable cache (that's the reason why we don't build
+    # this along linux and windows, the builds is just too slow, and linux
+    # covers most of the cases for a unix-y OS)
+    # - uses: actions/cache@v1
+    #   name: Cache stack files
+    #   with:
+    #     path: ${{ steps.setuphaskell.outputs.stack-root }}
+    #     key: ${{ runner.os }}-${{ matrix.snapshot }}-stack2
 
     - name: Setup stack.yaml
       shell: bash
       run: |
+        set -x
         mv -vf "stack-ci.yaml" ./stack.yaml || true
         mv -vf "stack-${{ matrix.snapshot }}.yaml" ./stack.yaml || true
         mv -vf "stack-${{ matrix.snapshot }}-${{ matrix.os }}.yaml" ./stack.yaml || true
@@ -55,22 +58,19 @@ jobs:
     - name: Build and test
       shell: bash
       run: |
+        set -x
         grep . stack.yaml
         if grep SKIP stack.yaml; then
           echo Skipped because that snapshot is broken
           exit 0
         fi
         stack setup --resolver=${{ matrix.snapshot }}
-        echo stack_root: $STACK_ROOT
+        echo "stack_root: ${{ steps.setuphaskell.outputs.stack-root }}"
         stack --version
         stack --resolver=${{ matrix.snapshot }} ghc -- --version
-        attempts=0
-        stack clean --resolver=${{ matrix.snapshot }}
-        while ! stack build -j 1 --resolver=${{ matrix.snapshot }} --ghc-options=-Werror --test --bench; do
-          if [ "$attempts" -gt 5 ]; then
-            echo "too many attempts ($attempts)"
-            exit 1
-          fi
-          echo Deps install failed, retrying
-          attempts=$(( $attempts + 1))
-        done
+        # we first build everything without running the tests (with unlimited parallelism)
+        stack build --resolver=${{ matrix.snapshot }} --ghc-options=-Werror --test --bench --no-run-tests
+
+        # once that's done we run the tests in a single threaded fashion to avoid
+        # https://github.com/commercialhaskell/stack/issues/5024#issuecomment-845001389
+        stack build --resolver=${{ matrix.snapshot }} --ghc-options=-Werror --test --bench -j 1

--- a/packages/aeson/conferer-aeson.cabal
+++ b/packages/aeson/conferer-aeson.cabal
@@ -1,10 +1,9 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a277c3aeb83a24c25a9b3314660add906a9c3a3420bee5b7b13a1f244a3f0210
 
 name:           conferer-aeson
 version:        1.1.0.1
@@ -33,12 +32,18 @@ library
       Paths_conferer_aeson
   hs-source-dirs:
       src
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
   build-depends:
       aeson >=0.10 && <2.0
     , base >=4.3 && <5
-    , bytestring >=0.10 && <0.11
+    , bytestring ==0.10.*
     , conferer >=1.1.0.0 && <2.0.0.0
     , directory >=1.2 && <2.0
     , text >=1.1 && <1.3
@@ -57,13 +62,19 @@ test-suite specs
       Paths_conferer_aeson
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererAesonSpecMain
   build-depends:
       aeson >=0.10 && <2.0
     , aeson-qq
     , base >=4.3 && <5
-    , bytestring >=0.10 && <0.11
+    , bytestring ==0.10.*
     , conferer
     , conferer-aeson
     , directory >=1.2 && <2.0

--- a/packages/conferer/conferer.cabal
+++ b/packages/conferer/conferer.cabal
@@ -1,10 +1,9 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7047fb1b6c4ba214affd2ca1a654f1914a857ed6a36e5b2136b40e04c5b9b693
 
 name:           conferer
 version:        1.1.0.0
@@ -51,11 +50,17 @@ library
       Paths_conferer
   hs-source-dirs:
       src
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
   build-depends:
       base >=4.3 && <5
-    , bytestring >=0.10 && <0.11
+    , bytestring ==0.10.*
     , containers >=0.5 && <0.7
     , directory >=1.2 && <2.0
     , filepath >=1.0 && <2.0
@@ -89,12 +94,18 @@ test-suite specs
       Paths_conferer
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererSpecMain
   build-depends:
       QuickCheck
     , base >=4.3 && <5
-    , bytestring >=0.10 && <0.11
+    , bytestring ==0.10.*
     , conferer
     , containers >=0.5 && <0.7
     , deepseq

--- a/packages/dhall/conferer-dhall.cabal
+++ b/packages/dhall/conferer-dhall.cabal
@@ -1,10 +1,9 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e7a6894c4340463874ee057abfcf3dde4b94bb05618151c6850f6807ef85fc7d
 
 name:           conferer-dhall
 version:        1.1.0.0
@@ -32,11 +31,17 @@ library
       Paths_conferer_dhall
   hs-source-dirs:
       src
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
   build-depends:
       base >=4.3 && <5
-    , bytestring >=0.10 && <0.11
+    , bytestring ==0.10.*
     , conferer >=1.1.0.0 && <2.0.0.0
     , conferer-aeson >=1.1.0.0 && <2.0.0.0
     , dhall >=1.8 && <2.0
@@ -54,11 +59,17 @@ test-suite specs
       Paths_conferer_dhall
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererDhallSpecMain
   build-depends:
       base >=4.3 && <5
-    , bytestring >=0.10 && <0.11
+    , bytestring ==0.10.*
     , conferer >=1.1.0.0 && <2.0.0.0
     , conferer-aeson >=1.1.0.0 && <2.0.0.0
     , conferer-dhall

--- a/packages/hedis/conferer-hedis.cabal
+++ b/packages/hedis/conferer-hedis.cabal
@@ -1,10 +1,9 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ce68464a13b964af2188b07e120c298253aa39bde0d8674cd30517b9a67fb552
 
 name:           conferer-hedis
 version:        1.1.0.0
@@ -32,7 +31,13 @@ library
       Paths_conferer_hedis
   hs-source-dirs:
       src
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
   build-depends:
       base >=4.3 && <5
@@ -51,7 +56,13 @@ test-suite specs
       Paths_conferer_hedis
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererHedisSpecMain
   build-depends:
       base >=4.3 && <5

--- a/packages/hspec/conferer-hspec.cabal
+++ b/packages/hspec/conferer-hspec.cabal
@@ -1,10 +1,9 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8cbf05cd31a3fd9b301a9a87b6e16d4f7486b6aa5fee691717675911833ab6a1
 
 name:           conferer-hspec
 version:        1.1.0.0
@@ -32,7 +31,13 @@ library
       Paths_conferer_hspec
   hs-source-dirs:
       src
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
   build-depends:
       base >=4.3 && <5
@@ -51,7 +56,13 @@ test-suite specs
       Paths_conferer_hspec
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererHspecSpecMain
   build-depends:
       base >=4.3 && <5

--- a/packages/snap/conferer-snap.cabal
+++ b/packages/snap/conferer-snap.cabal
@@ -1,10 +1,9 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5d4c8a222d0ba1f283daf6c54c3271298776195e55ecc6c1a0db2e62ba7e4484
 
 name:           conferer-snap
 version:        1.0.0.0
@@ -32,7 +31,13 @@ library
       Paths_conferer_snap
   hs-source-dirs:
       src
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
   build-depends:
       base >=4.3 && <5
@@ -52,7 +57,13 @@ test-suite specs
       Paths_conferer_snap
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererSnapSpecMain
   build-depends:
       base >=4.3 && <5

--- a/packages/warp/conferer-warp.cabal
+++ b/packages/warp/conferer-warp.cabal
@@ -1,10 +1,9 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: df73f5f80e54466703aced50513b638f4bc33dc0331ba7874c4370b0f032207e
 
 name:           conferer-warp
 version:        1.1.0.0
@@ -32,7 +31,13 @@ library
       Paths_conferer_warp
   hs-source-dirs:
       src
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
   build-depends:
       base >=4.3 && <5
@@ -53,7 +58,13 @@ test-suite specs
       Paths_conferer_warp
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererWarpSpecMain
   build-depends:
       base >=4.3 && <5

--- a/packages/yaml/conferer-yaml.cabal
+++ b/packages/yaml/conferer-yaml.cabal
@@ -1,10 +1,8 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 91a59b94b272100a2091d299af7f6e568f71956e14610b4297345ac4033a1c01
 
 name:           conferer-yaml
 version:        1.1.0.0
@@ -32,7 +30,13 @@ library
       Paths_conferer_yaml
   hs-source-dirs:
       src
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns
   build-depends:
       base >=4.3 && <5
@@ -51,7 +55,13 @@ test-suite specs
       Paths_conferer_yaml
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings LambdaCase QuasiQuotes ScopedTypeVariables RecordWildCards StrictData
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      QuasiQuotes
+      ScopedTypeVariables
+      RecordWildCards
+      StrictData
   ghc-options: -Wall -Wredundant-constraints -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -main-is ConfererYamlSpecMain
   build-depends:
       base >=4.3 && <5


### PR DESCRIPTION
# Description

Replace the old [action/haskell](https://github.com/actions/setup-haskell) (which is now deprecated) with the newer [haskell/setup](https://github.com/haskell/actions/tree/main/setup), and also submit changes that upgrading to stack 2.7.1 caused

# Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added changes to the relevant changelog
- [ ] I have made corresponding changes to the documentation
- [ ] I have added haddock comments for every new function and data
