### PR TITLE
Refactor keys to rehuse the validation logic

### DIFF
--- a/packages/aeson/src/Conferer/Source/Aeson.hs
+++ b/packages/aeson/src/Conferer/Source/Aeson.hs
@@ -282,7 +282,7 @@ parseValue = go ""
   where
   go key (Object o) = do
     let
-      (validKeys, invalidKeys) = partition (isValidKeyFragment . fst)
+      (validKeys, invalidKeys) = partition (isKeyFragment . fst)
         $ HashMap.toList
         $ HashMap.delete "_self" o
     unless (null invalidKeys) $

--- a/packages/conferer/CHANGELOG.md
+++ b/packages/conferer/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [PVP](https://pvp.haskell.org/).
 * `TestSource` which is like `InMemorySource` but throws when asking to explain keys (should be only
   used for testing)
 * `Generic` based instance of `FromConfig` now also strips `_` and `_constructorName`
+* expose `mkKeyFragment`, `isKeyCharacter` and `mkKeyCharacter` and rename `isValidKeyFragment` to
+  `isKeyFragment` for consistency
 
 ### Removed
 

--- a/packages/conferer/src/Conferer/Key.hs
+++ b/packages/conferer/src/Conferer/Key.hs
@@ -8,6 +8,7 @@
 -- Public API for Key related features
 module Conferer.Key
   ( Key
+  , KeyFragment
   -- * Creating 'Key's
   , mkKey
   , fromText
@@ -15,8 +16,12 @@ module Conferer.Key
   , (/.)
   , stripKeyPrefix
   , isKeyPrefixOf
-  , isValidKeyFragment
+
+  , mkKeyFragment
+  , isKeyFragment
+
   , isKeyCharacter
+  , mkKeyCharacter
   -- * Introspecting 'Key's
   , rawKeyComponents
   , unconsKey

--- a/packages/conferer/src/Conferer/Key/Internal.hs
+++ b/packages/conferer/src/Conferer/Key/Internal.hs
@@ -14,6 +14,8 @@ import qualified Data.Text as Text
 import Data.Function (on)
 import Data.List (stripPrefix, isPrefixOf)
 import qualified Data.Char as Char
+import Data.Maybe (mapMaybe)
+
 -- | This type is used extensivelly as a way to point into a 'Conferer.Source.Source'
 --   and in turn into a 'Conferer.Config.Config'. The intended way to create them is
 --   is using 'mkKey'.
@@ -21,11 +23,21 @@ import qualified Data.Char as Char
 --   It's a list of alphanumeric words and each 'Conferer.Source.Source' can interpret
 --   it as it sees fit.
 newtype Key = Key
-  { unKey :: [Text]
+  { unKey :: [KeyFragment]
   } deriving (Eq, Ord)
+
+newtype KeyFragment = KeyFragment
+  { unKeyFragment :: Text
+  } deriving (Eq, Ord, Show)
 
 instance Show Key where
   show key = "\"" ++ Text.unpack (keyName key) ++ "\""
+
+instance IsString KeyFragment where
+  fromString s =
+    case mkKeyFragment . Text.pack $ s of
+      Just k -> k
+      Nothing -> error $ "'" ++ s ++ "' is not a valid key fragment"
 
 instance IsString Key where
   fromString = mkKey
@@ -44,11 +56,47 @@ instance IsString Key where
 mkKey :: String -> Key
 mkKey s =
   Key .
-  filter (/= mempty) .
-  fmap (Text.filter isKeyCharacter . Text.toLower) .
+  mapMaybe mkKeyFragment .
   Text.split (== '.') .
-  fromString
-  $ s
+  fromString $ if s == "." then "" else s
+
+-- | Given some 'Text' try to parse it into a 'KeyFragment', which are
+-- lowercase ascii or numbers.
+--
+-- NOTE: In case of invalid characters this function will either coherce them
+-- (for uppercase characters) or drop them, if you want to check without
+-- conversions use 'isKeyFragment'.
+mkKeyFragment :: Text -> Maybe KeyFragment
+mkKeyFragment t =
+  let keyString =
+        mapMaybe mkKeyCharacter $ Text.unpack t
+  in if null keyString
+      then Nothing
+      else Just $ KeyFragment $ Text.pack keyString
+
+-- | Given some 'Char', try to turn it into a 'Char' valid for a 'KeyFragment'
+-- which is lowercase ascii or numbers.
+--
+-- NOTE: In case of uppercase characters this function will lowercase them, if
+-- you want to check if a 'Char' is valid without conversions use 'isKeyCharacter'
+mkKeyCharacter :: Char -> Maybe Char
+mkKeyCharacter c
+  | Char.isDigit c = Just c
+  | Char.isAsciiLower c = Just c
+  | Char.isAsciiUpper c = Just $ Char.toLower c
+  | otherwise = Nothing
+
+-- | Check if a 'Text' is a valid fragment of a 'Key', meaning
+-- that each character 'isKeyCharacter'
+isKeyFragment :: Text -> Bool
+isKeyFragment t =
+  fmap unKeyFragment (mkKeyFragment t) == Just t
+
+-- | Checks if the given 'Char' is a valid for a 'Key'.
+-- Meaning it is a lower case ascii letter or a number.
+isKeyCharacter :: Char -> Bool
+isKeyCharacter c =
+  mkKeyCharacter c == Just c
 
 -- | Same as 'mkKey' but for 'Text'
 fromText :: Text -> Key
@@ -56,7 +104,10 @@ fromText = mkKey . Text.unpack
 
 -- | Collapse a key into a textual representation
 keyName :: Key -> Text
-keyName = Text.intercalate "." . unKey
+keyName k =
+  case k of
+    Key [] -> "."
+    _ -> Text.intercalate "." . rawKeyComponents $ k
 
 -- | This function tells if a key is a subkey of another key based
 --   using key fragments instead of letters as units
@@ -83,21 +134,10 @@ parent /. child = Key (unKey parent ++ unKey child)
 
 -- | Get raw components from a key, usually to do some manipulation
 rawKeyComponents :: Key -> [Text]
-rawKeyComponents = unKey
+rawKeyComponents = fmap unKeyFragment . unKey
 
 -- | Get first component of a key and the rest of the key
 unconsKey :: Key -> Maybe (Text, Key)
 unconsKey (Key []) = Nothing
-unconsKey (Key (k:ks)) = Just (k, Key ks)
+unconsKey (Key (k:ks)) = Just (unKeyFragment k, Key ks)
 
--- | Check if a 'Text' is a valid fragment of a 'Key', meaning
--- that each character 'isKeyCharacter'
-isValidKeyFragment :: Text -> Bool
-isValidKeyFragment t =
-  (not $ Text.null t) && Text.all isKeyCharacter t
-
--- | Checks if the given 'Char' is a valid for a 'Key'.
--- Meaning it is a lower case ascii letter or a number.
-isKeyCharacter :: Char -> Bool
-isKeyCharacter c =
-  Char.isAsciiLower c || Char.isDigit c

--- a/packages/conferer/test/Conferer/KeySpec.hs
+++ b/packages/conferer/test/Conferer/KeySpec.hs
@@ -21,19 +21,19 @@ spec = do
   describe "#isValidKeyFragment" $ do
     context "with a all leters" $ do
       it "is valid" $
-        isValidKeyFragment "fragment" `shouldBe` True
+        isKeyFragment "fragment" `shouldBe` True
     context "with only numbers" $ do
       it "is valid" $
-        isValidKeyFragment "000" `shouldBe` True
+        isKeyFragment "000" `shouldBe` True
     context "with both numbers and letters" $ do
       it "is valid" $
-        isValidKeyFragment "000" `shouldBe` True
+        isKeyFragment "fragment000" `shouldBe` True
     context "with a dot" $ do
       it "is not valid" $ do
-        isValidKeyFragment "some.fragment" `shouldBe` False
+        isKeyFragment "some.fragment" `shouldBe` False
     context "with an uppercase letter" $ do
       it "is not valid" $ do
-        isValidKeyFragment "FRAGMENT" `shouldBe` False
+        isKeyFragment "FRAGMENT" `shouldBe` False
     context "with an empty string" $ do
       it "is not valid" $ do
-        isValidKeyFragment "" `shouldBe` False
+        isKeyFragment "" `shouldBe` False


### PR DESCRIPTION
# Description

This is just a small refactor that adds and exposes a couple of functions to unify validating `Keys`

Fixes #(issue)

# Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added changes to the relevant changelog
- [x] I have made corresponding changes to the documentation
- [x] I have added haddock comments for every new function and data
